### PR TITLE
Makefile.in: replace 'test ! -e' => 'test ! -s'

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -114,7 +114,7 @@ asy:	version
 	fi
 
 version: $(GCLIB) $(FILES:=.o)
-	if test ! -e revision.cc -o "$(revision)" != "$(last)"; then     \
+	if test ! -s revision.cc -o "$(revision)" != "$(last)"; then     \
 	  echo $(REVISION)\"$(revision)\"\; > revision.cc; \
 	fi
 	$(CXX) $(OPTS) $(INCL) -o revision.o -c revision.cc;


### PR DESCRIPTION
Karl Berry wrote:

> in `asymptote/Makefile.in`, the version target starts with:
>
>  `if test ! -e revision.cc -o "$(revision)" != "$(last)"; then \`
>
> Sadly, this is not portable to the original Bourne shell, which is still
> /bin/sh on current Solaris (and always will be).  The solution is to
> change `-e` to `-s`.  (The `-e` operator isn't supported by the builtin test
> operator in that old version.)
