### PR TITLE
Configurable filltype for dot

### DIFF
--- a/base/plain_markers.asy
+++ b/base/plain_markers.asy
@@ -305,7 +305,9 @@ pair[] pairs(real[] x, real[] y)
   return sequence(new pair(int i) {return (x[i],y[i]);},x.length);
 }
 
-void dot(frame f, pair z, pen p=currentpen, filltype filltype=Fill)
+filltype dotfilltype = Fill;
+
+void dot(frame f, pair z, pen p=currentpen, filltype filltype=dotfilltype)
 {
   if(filltype == Fill)
     draw(f,z,dotsize(p)+p);
@@ -320,7 +322,7 @@ void dot(frame f, pair z, pen p=currentpen, filltype filltype=Fill)
 }
 
 void dot(picture pic=currentpicture, pair z, pen p=currentpen,
-         filltype filltype=Fill)
+         filltype filltype=dotfilltype)
 {
   pic.add(new void(frame f, transform t) {
       dot(f,t*z,p,filltype);
@@ -329,7 +331,7 @@ void dot(picture pic=currentpicture, pair z, pen p=currentpen,
 }
 
 void dot(picture pic=currentpicture, Label L, pair z, align align=NoAlign,
-         string format=defaultformat, pen p=currentpen, filltype filltype=Fill)
+         string format=defaultformat, pen p=currentpen, filltype filltype=dotfilltype)
 {
   Label L=L.copy();
   L.position(z);
@@ -345,7 +347,7 @@ void dot(picture pic=currentpicture, Label L, pair z, align align=NoAlign,
 
 void dot(picture pic=currentpicture, Label[] L=new Label[], pair[] z,
 	 align align=NoAlign, string format=defaultformat, pen p=currentpen,
-	 filltype filltype=Fill)
+	 filltype filltype=dotfilltype)
 {
   int stop=min(L.length,z.length);
   for(int i=0; i < stop; ++i)
@@ -356,7 +358,7 @@ void dot(picture pic=currentpicture, Label[] L=new Label[], pair[] z,
 
 void dot(picture pic=currentpicture, Label[] L=new Label[],
 	 explicit path g, align align=RightSide, string format=defaultformat,
-	 pen p=currentpen, filltype filltype=Fill)
+	 pen p=currentpen, filltype filltype=dotfilltype)
 {
   int n=size(g);
   int stop=min(L.length,n);
@@ -367,20 +369,20 @@ void dot(picture pic=currentpicture, Label[] L=new Label[],
 }
 
 void dot(picture pic=currentpicture, path[] g, pen p=currentpen,
-         filltype filltype=Fill)
+         filltype filltype=dotfilltype)
 {
   for(int i=0; i < g.length; ++i)
     dot(pic,g[i],p,filltype);
 }
 
 void dot(picture pic=currentpicture, Label L, pen p=currentpen,
-         filltype filltype=Fill)
+         filltype filltype=dotfilltype)
 {
   dot(pic,L,L.position,p,filltype);
 }
 
 // A dot in a frame.
-frame dotframe(pen p=currentpen, filltype filltype=Fill)
+frame dotframe(pen p=currentpen, filltype filltype=dotfilltype)
 {
   frame f;
   dot(f,(0,0),p,filltype);
@@ -389,7 +391,7 @@ frame dotframe(pen p=currentpen, filltype filltype=Fill)
 
 frame dotframe=dotframe();
 
-marker dot(pen p=currentpen, filltype filltype=Fill)
+marker dot(pen p=currentpen, filltype filltype=dotfilltype)
 {
   return marker(dotframe(p,filltype));
 }

--- a/doc/asymptote.texi
+++ b/doc/asymptote.texi
@@ -1217,13 +1217,19 @@ default line width magnified by @code{dotfactor} (6 by default),
 using the specified filltype (@pxref{filltype}) or @code{dotfilltype}
 (@code{Fill} by default):
 @verbatim
+void dot(frame f, pair z, pen p=currentpen, filltype filltype=dotfilltype);
 void dot(picture pic=currentpicture, pair z, pen p=currentpen,
          filltype filltype=dotfilltype);
 void dot(picture pic=currentpicture, Label L, pair z, align align=NoAlign,
          string format=defaultformat, pen p=currentpen, filltype filltype=dotfilltype);
 void dot(picture pic=currentpicture, Label[] L=new Label[], pair[] z,
          align align=NoAlign, string format=defaultformat, pen p=currentpen,
-         filltype filltype=dotfilltype)
+         filltype filltype=dotfilltype);
+void dot(picture pic=currentpicture, Label[] L=new Label[],
+         explicit path g, align align=RightSide, string format=defaultformat,
+         pen p=currentpen, filltype filltype=dotfilltype);
+void dot(picture pic=currentpicture, path[] g, pen p=currentpen,
+         filltype filltype=dotfilltype);
 void dot(picture pic=currentpicture, Label L, pen p=currentpen,
          filltype filltype=dotfilltype);
 @end verbatim

--- a/doc/asymptote.texi
+++ b/doc/asymptote.texi
@@ -1225,9 +1225,6 @@ void dot(picture pic=currentpicture, Label L, pair z, align align=NoAlign,
 void dot(picture pic=currentpicture, Label[] L=new Label[], pair[] z,
          align align=NoAlign, string format=defaultformat, pen p=currentpen,
          filltype filltype=dotfilltype);
-void dot(picture pic=currentpicture, Label[] L=new Label[],
-         explicit path g, align align=RightSide, string format=defaultformat,
-         pen p=currentpen, filltype filltype=dotfilltype);
 void dot(picture pic=currentpicture, path[] g, pen p=currentpen,
          filltype filltype=dotfilltype);
 void dot(picture pic=currentpicture, Label L, pen p=currentpen,
@@ -1236,14 +1233,14 @@ void dot(picture pic=currentpicture, Label L, pen p=currentpen,
 
 @cindex @code{Label}
 If the variable @code{Label} is given as the @code{Label}
-argument to the second routine, the @code{format} argument will be
+argument to the third routine, the @code{format} argument will be
 used to format a string based on the dot location (here @code{defaultformat}
 is @code{"$%.4g$"}). 
-The third routine draws a dot at every point of a pair array @code{z}.
+The fourth routine draws a dot at every point of a pair array @code{z}.
 One can also draw a dot at every node of a path:
 @verbatim
 void dot(picture pic=currentpicture, Label[] L=new Label[],
-         path g, align align=RightSide, string format=defaultformat,
+         explicit path g, align align=RightSide, string format=defaultformat,
          pen p=currentpen, filltype filltype=dotfilltype);
 @end verbatim
 See @ref{pathmarkers} and @ref{markers} for more general

--- a/doc/asymptote.texi
+++ b/doc/asymptote.texi
@@ -1214,17 +1214,18 @@ To draw a dot, simply draw a path containing a single point.
 The @code{dot} command defined in the module @code{plain} draws a
 dot having a diameter equal to an explicit pen line width or the
 default line width magnified by @code{dotfactor} (6 by default),
-using the specified filltype (@pxref{filltype}):
+using the specified filltype (@pxref{filltype}) or @code{dotfilltype}
+(@code{Fill} by default):
 @verbatim
 void dot(picture pic=currentpicture, pair z, pen p=currentpen,
-         filltype filltype=Fill);
+         filltype filltype=dotfilltype);
 void dot(picture pic=currentpicture, Label L, pair z, align align=NoAlign,
-         string format=defaultformat, pen p=currentpen, filltype filltype=Fill);
+         string format=defaultformat, pen p=currentpen, filltype filltype=dotfilltype);
 void dot(picture pic=currentpicture, Label[] L=new Label[], pair[] z,
          align align=NoAlign, string format=defaultformat, pen p=currentpen,
-         filltype filltype=Fill)
+         filltype filltype=dotfilltype)
 void dot(picture pic=currentpicture, Label L, pen p=currentpen,
-         filltype filltype=Fill);
+         filltype filltype=dotfilltype);
 @end verbatim
 
 @cindex @code{Label}
@@ -1237,7 +1238,7 @@ One can also draw a dot at every node of a path:
 @verbatim
 void dot(picture pic=currentpicture, Label[] L=new Label[],
          path g, align align=RightSide, string format=defaultformat,
-         pen p=currentpen, filltype filltype=Fill);
+         pen p=currentpen, filltype filltype=dotfilltype);
 @end verbatim
 See @ref{pathmarkers} and @ref{markers} for more general
 methods for marking path nodes.


### PR DESCRIPTION
Hi, this commit preserves current behavior of Asymptote but enables configuring the `filltype` for `dot`. Idea was presented on [Art of Problem Solving forum](https://artofproblemsolving.com/community/c68h269648p7775748). Kind regards, Ivan