### PR TITLE
Allow overriding binaries in Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -79,9 +79,9 @@ SHAREDOPTS = $(filter-out -DUSEGC, $(OPTS)) -fPIC -DFOR_SHARED
 CXX = @CXX@ -Wall
 CC = @CC@ -Wall
 MAKEDEPEND = $(OPTS) -O0 -M -DDEPEND
-BISON = bison
-PYRCC = pyrcc5
-PYUIC = pyuic5
+BISON ?= bison
+PYRCC ?= pyrcc5
+PYUIC ?= pyuic5
 LEX = @LEX@
 
 prefix = @prefix@


### PR DESCRIPTION
This should allow an easier way of overriding names of some executables needed when building asymptote.