### PR TITLE
Fix issue #123

### DIFF
--- a/texfile.cc
+++ b/texfile.cc
@@ -86,7 +86,7 @@ void texfile::prologue()
       if(width > 0) 
         *out << "\\pdfpagewidth=" << width << "bp" << newl;
       *out << "\\ifx\\pdfhorigin\\undefined" << newl
-           << "\\makeatletter\\@ifpackageloaded{luaotfload}{\\hoffset=-72.4bp}{\\hoffset=-72.0bp}\\makeatother" << newl
+           << "\\hoffset=-1in" << newl
            << "\\voffset=" << voffset-72.0 << "bp" << newl;
       if(height > 0)
         *out << "\\pdfpageheight=" << height << "bp" 

--- a/texfile.cc
+++ b/texfile.cc
@@ -110,7 +110,8 @@ void texfile::prologue()
            << "\\textheight=" << height+18.0 << "bp" << newl
            << "\\textwidth=" << width+18.0 << "bp" << newl;
       if(settings::pdf(texengine))
-        *out << "\\oddsidemargin=-17.61pt" << newl
+        *out << "\\parindent=0pt" << newl
+             << "\\oddsidemargin=0pt" << newl
              << "\\evensidemargin=\\oddsidemargin" << newl
              << "\\topmargin=-37.01pt" << newl;
       *out << "\\begin{document}" << newl;


### PR DESCRIPTION
Fix offset settings where texengine is latex and pdf #123.

The issue is caused by a wrong assumption that `\parindent` were always `17.61pt`.
It is not caused by lualatex bug.
So, we set as follows:

    \parindent=0pt
    \oddsidemargin=0pt