### PR TITLE
Capitalize Windows override in xasy config

### DIFF
--- a/GUI/configs/xasyconfig.cson
+++ b/GUI/configs/xasyconfig.cson
@@ -54,7 +54,7 @@ debugMode: true
 
 # Overrides
 
-windows:
+Windows:
     externalEditor: "notepad.exe"
 
 Darwin:


### PR DESCRIPTION
* close #160 
* in [`xasyOptions`](https://github.com/vectorgraphics/asymptote/blob/56f89ede630ce95f6d0e57c5adf58bc925229ad8/GUI/xasyOptions.py#L44-L51)
* `platform.system()` returns "Windows" capitalized
* check for overrides is case sensitive
* alternate is to add `lower()`