### PR TITLE
comment out os.chdir(tempDir) in asyfy xasy2asy.py

### DIFF
--- a/GUI/xasy2asy.py
+++ b/GUI/xasy2asy.py
@@ -712,6 +712,7 @@ class xasyItem(Qc.QObject):
     def handleImageReception(self, file, fileformat, bbox, count, key=None, localCount=0, containsClip=False):
         """Receive an image from an asy deconstruction. It replaces the default n asyProcess."""
         # image = Image.open(file).transpose(Image.FLIP_TOP_BOTTOM)
+        print(file)
         if fileformat == 'png':
             image = Qg.QImage(file)
         elif fileformat == 'svg':

--- a/GUI/xasy2asy.py
+++ b/GUI/xasy2asy.py
@@ -775,8 +775,8 @@ class xasyItem(Qc.QObject):
         worker = threading.Thread(target=self.asyfyThread, args=[])
         worker.start()
         item = self.imageHandleQueue.get()
-        cwd=os.getcwd();
-        os.chdir(self.asyengine.tempDirName)
+        #cwd=os.getcwd();
+        #os.chdir(self.asyengine.tempDirName)
         while item != (None,) and item[0] != "ERROR":
             if item[0] == "OUTPUT":
                 print(item[1])
@@ -792,7 +792,7 @@ class xasyItem(Qc.QObject):
                         pass
             item = self.imageHandleQueue.get()
         # self.imageHandleQueue.task_done()
-        os.chdir(cwd);
+        #os.chdir(cwd);
 
         worker.join()
 


### PR DESCRIPTION
* closes #162  
* don't need to change directories to tempDir, because tempDir is already in path of file in item
* file is relative to whatever directory xasy is launched from, ususally %HOME% if using the shortcuts in the startmenu or the desktop