### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/doc/FAQ/asy-faq.bfnn
+++ b/doc/FAQ/asy-faq.bfnn
@@ -9,7 +9,7 @@
 \set title      Asymptote Frequently Asked Questions
 \copyto ASCII
             ASYMPTOTE FREQUENTLY ASKED QUESTIONS
-                            `date '+%d %h %Y'`
+                            `%perl use POSIX; POSIX::strftime("%Y-%m-%d", gmtime($ENV{SOURCE_DATE_EPOCH} || time))`
                            
 \endcopy
 \copyto INFO
@@ -22,7 +22,7 @@ END-INFO-DIR-ENTRY
 File: asy-faq.info, Node: Top, Next: Question 1.1, Up: (dir)
 
             ASYMPTOTE FREQUENTLY ASKED QUESTIONS
-                            `date '+%d %h %Y'`
+                            `%perl use POSIX; POSIX::strftime("%Y-%m-%d", gmtime($ENV{SOURCE_DATE_EPOCH} || time))`
                           
 \endcopy
 

--- a/doc/FAQ/bfnnconv.pl
+++ b/doc/FAQ/bfnnconv.pl
@@ -135,7 +135,11 @@ while (<>) {
                 m/([^\\])\`/ || warn "`$_'";
                 $_= $';
                 $cmd= $`.$1;
-                $it= `$cmd`; chop $it;
+                if($cmd =~ s/^%perl //) {
+                    $it= eval($cmd);
+                } else {
+                    $it= `$cmd`; chop $it;
+                }
                 print $fh $it;
             }
             print $fh $_;

--- a/doc/FAQ/m-html.pl
+++ b/doc/FAQ/m-html.pl
@@ -22,6 +22,8 @@
 # by the GPL.  However, I would appreciate it if you credited me if
 # appropriate in any documents you format using BFNN.)
 
+use POSIX;
+
 %saniarray= ('<','lt', '>','gt', '&','amp', '"','quot');
 
 sub html_init {
@@ -34,8 +36,9 @@ sub html_init {
     print HTML "<html>\n";
     $html_needpara= -1;
     $html_end='';
-    chop($html_date=`date '+%d %B %Y'`);
-    chop($html_year=`date '+%Y'`);
+    my $epoch=$ENV{SOURCE_DATE_EPOCH} || time;
+    $html_date=POSIX::strftime("%Y-%m-%d", gmtime($epoch));
+    $html_year=POSIX::strftime("%Y", gmtime($epoch));
 }
 
 sub html_startup {


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also consistently use ISO 8601 date format to be understood everywhere.
This also avoids %B and %h that are locale-dependent.

Also use UTC/gmtime to be independent of timezone.

Also rewrite the shell `date` calls into perl to avoid
trouble with the different date command implementations.

This PR was done while working on reproducible builds for openSUSE.