### PR TITLE
Fix issue preventing asymptote from working with Ghostscript 9.35.0+

### DIFF
--- a/runlabel.in
+++ b/runlabel.in
@@ -106,14 +106,27 @@ array *readpath(const string& psname, bool keep, bool pdf=false,
   cmd.push_back("-dBATCH");
   cmd.push_back("-P");
   if(safe) cmd.push_back("-dSAFER");
+// Before Ghostscript 9.35.0, we could use /dev/null (or NUL on Windows)
+// as an OutputFile, but after this version, the epswrite driver explicitly
+// checks for multi-page output and errors out unless the OutputFile value
+// contains %d (to write multiple files).
+// Given the options of:
+// 1. Teach ghostscript to recognize /dev/null (NUL on Windows) as a special
+//    exception for this logic in epswrite
+// 2. Use a different DEVICE type than epswrite
+// 3. Output to /tmp files (or %TEMP%\ on Windows)
+//
+// I changed the code here to do #3 as that seemed the least intrusive.
+// NOTE: Nothing in asymptote actually cleans up these temp files, but
+// nothing depends on them either.
 #ifdef __MSDOS__
-  const string null="NUL";
+  const string tempmf="%TEMP%\asy%d.tmp";
 #else
-  const string null="/dev/null";
+  const string tempmf="/tmp/asy%d.tmp";
 #endif
   string epsdriver=getSetting<string>("epsdriver");
   cmd.push_back("-sDEVICE="+epsdriver);
-  cmd.push_back("-sOutputFile="+null);
+  cmd.push_back("-sOutputFile="+tempmf);
   cmd.push_back(stripDir(psname));
   iopipestream gs(cmd,"gs","Ghostscript");
   while(gs.running()) {


### PR DESCRIPTION
As reported in #176, asymptote no longer works with Ghostscript versions newer than 9.35.0. Took me a bit to figure out why, but the epswrite driver in gs no longer permits multi-page output to a single file. The asymptote code in runlabel.in (and later, runlavel.cc) sets the output to /dev/null (or NUL on Windows). Since this is a single file, gs errors out.

As I described in the comment I placed with this change, the only viable options I saw were to:

1. Patch ghostscript to detect /dev/null (or NUL) as exempt from the multi-page output restriction logic
2. Change the gs driver used in this part of asymptote from epswrite to something else which has no multi-page issues
3. Instead of writing to /dev/null or (NUL), write out temp files (to /tmp/ or %TEMP%\) using the %d option to permit multiple file output

This PR implements Option 3. I did not think it was likely that upstream Ghostscript would take a change to handle NULL device output in a special way (though, I certainly could be wrong about this, I did not attempt it). I also was unsure if another gs driver type would produce the same output (and I do not understand the gs internals well enough to even guess here). This approach seemed like the simplest and most correct.

I did not add any code to cleanup the temp files that asy now outputs, but nothing depends on them either.

Finally, I only tested this on Fedora (Linux). I _think_ this should work properly on Windows, but I do not have that environment to test with.