### PR TITLE
Fix Gouraud image scaling

### DIFF
--- a/base/palette.asy
+++ b/base/palette.asy
@@ -190,8 +190,8 @@ bounds image(picture pic=currentpicture, pair[] z, real[] f,
   real rmax=pic.scale.z.T(bounds.max);
 
   palette=adjust(pic,m,M,rmin,rmax,palette);
-  rmin=max(rmin,m);
-  rmax=min(rmax,M);
+  rmin=max(rmin,pic.scale.z.T(m));
+  rmax=min(rmax,pic.scale.z.T(M));
 
   // Crop data to allowed range and scale
   if(range != Full || pic.scale.z.scale.T != identity ||

--- a/base/palette.asy
+++ b/base/palette.asy
@@ -201,6 +201,12 @@ bounds image(picture pic=currentpicture, pair[] z, real[] f,
     real M=bounds.max;
     f=map(new real(real x) {return T(min(max(x,m),M));},f);
   }
+  if(pic.scale.x.scale.T != identity || pic.scale.x.postscale.T != identity ||
+     pic.scale.y.scale.T != identity || pic.scale.y.postscale.T != identity) {
+    scalefcn Tx=pic.scale.x.T;
+    scalefcn Ty=pic.scale.y.T;
+    z=map(new pair(pair z) {return (Tx(z.x),Ty(z.y));},z);
+  }
 
   int[] edges={0,0,1};
   int N=palette.length-1;


### PR DESCRIPTION
There's a very old commit (d0269b9d990cbf5677e67d43e9b85a969ef03bb8) that fix an issue ([SourceForge](https://sourceforge.net/p/asymptote/bugs/144)) with palette range in the Gouraud image function in `base/palette.asy`. That commit introduces a comparison between unscaled `m` and `M` and scaled `rmin` and  `rmax` values that leads to inconsistent palette range when z scale is not the identity.

This PR first fixes this issue and while we are at it, adds scaling to the x and y coordinates which are currently ignored by the function.