### PR TITLE
Qt macos accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ core.*
 /GUI/pyUIClass/*
 /GUI/__pycache__/*
 /.idea/*
+/GUI/.env
 
 examples/_ig_*.asy
 

--- a/GUI/Window1.py
+++ b/GUI/Window1.py
@@ -177,6 +177,9 @@ class MainWindow1(Qw.QMainWindow):
         self.scaleFactor = 1
         self.panOffset = [0, 0]
 
+        # Keyboard can focus outside fo textboxes 
+        self.setFocusPolicy(Qc.Qt.StrongFocus)
+
         super().setMouseTracking(True)
         # setMouseTracking(True)
         
@@ -759,6 +762,7 @@ class MainWindow1(Qw.QMainWindow):
         return Urs.action((_change, _undoChange))
 
     def execCustomCommand(self, command):
+        # print(f"The following command was used: {command}")
         if command in self.commandsFunc:
             self.commandsFunc[command]()
         else:

--- a/GUI/windows/window1.ui
+++ b/GUI/windows/window1.ui
@@ -605,7 +605,7 @@
             </property>
             <property name="maximumSize">
              <size>
-              <width>25</width>
+              <width>32</width>
               <height>25</height>
              </size>
             </property>
@@ -652,7 +652,7 @@
             </property>
             <property name="maximumSize">
              <size>
-              <width>25</width>
+              <width>32</width>
               <height>25</height>
              </size>
             </property>
@@ -2040,7 +2040,7 @@ background: rgb(0, 0, 0)
      <x>0</x>
      <y>0</y>
      <width>1000</width>
-     <height>29</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFIle">

--- a/GUI/windows/window1.ui
+++ b/GUI/windows/window1.ui
@@ -2040,7 +2040,7 @@ background: rgb(0, 0, 0)
      <x>0</x>
      <y>0</y>
      <width>1000</width>
-     <height>24</height>
+     <height>29</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFIle">


### PR DESCRIPTION
Previously, the shortcuts that were added weren't working (on mac in particular). This was because the keyboard would automatically focus onto the text boxes, and the default shortcuts for these textboxes would override the global ones that we created. 