### PR TITLE
Update asymptote.texi

### DIFF
--- a/doc/asymptote.texi
+++ b/doc/asymptote.texi
@@ -387,8 +387,8 @@ You will also need to install @code{GPL Ghostscript} version 9.52 or
 later from @url{http://downloads.ghostscript.com/public}.
 
 To view @code{PostScript} output, you can install the
-program @code{gsview} available from 
-@url{http://www.cs.wisc.edu/~ghost/gsview/}.
+program @code{Sumatra PDF} available from 
+@url{https://www.sumatrapdfreader.org/}.
 
 The @code{ImageMagick} package from
 @url{https://www.imagemagick.org/script/binary-releases.php} 


### PR DESCRIPTION
`GSView 6.0` is  end of life. 
`Sumatra PDF` can auto reload when the `.eps` is changed, and supports latest Ghostcript 9.54+.
https://forum.sumatrapdfreader.org/t/ghostscript-not-working-error-loading-on-ps-files/3826
https://github.com/sumatrapdfreader/sumatrapdf/commit/5a295db98381f925aa81d13988ffadf74953b8de