### PR TITLE
Improve vim syntax

### DIFF
--- a/base/asy.vim
+++ b/base/asy.vim
@@ -14,93 +14,27 @@ elseif exists("b:current_syntax")
   finish
 endif
 
-" A bunch of useful C keywords
+" useful C/C++/Java keywords
 syn keyword     asyStatement     break return continue unravel
 syn keyword     asyConditional   if else
 syn keyword     asyRepeat        while for do
 syn keyword     asyExternal      access from import include
 syn keyword     asyOperator      new operator
 
-syn keyword     asyTodo          contained TODO FIXME XXX
-
-" asyCommentGroup allows adding matches for special things in comments
-syn cluster     asyCommentGroup  contains=asyTodo
-
-" String and Character constants
-syn region      asyCString       start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=asyCSpecial
-syn match       asyCSpecial      display contained +\\\(['"?\\abfnrtv]\|\o\{1,3}\|x[0-9A-F]\{1,2\}\|$\)+
-" double quoted strings only special character is \"
-syn region      asyString        start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=asySpecial
-syn match       asySpecial       display contained +[^\\]\(\\\\\)*\zs\\"+
-
-"catch errors caused by wrong parenthesis and brackets
-syn cluster     asyParenGroup    contains=asyParenError,asyIncluded,asySpecial,asyCSpecial,asyCommentSkip,asyCommentString,asyCommentLString,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
-if exists("asy_no_bracket_error")
-  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyCppString
-  " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString,asyCString
-  syn match     asyParenError    display ")"
-  syn match     asyErrInParen    display contained "[{}]"
-else
-  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyErrInBracket,asyCppBracket,asyCppString
-  " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString,asyCString
-if 0
-  syn match     asyParenError    display "[\])]"
-  syn match     asyErrInParen    display contained "[\]]"
-endif
-  syn region    asyBracket       transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen,asyCppParen,asyCppBracket,asyCppString
-  " asyCppBracket: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppBracket    transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString,asyCString
-  syn match     asyErrInBracket  display contained "[);]"
-endif
-
-"integer number, or floating point number without a dot and with "f".
-syn case ignore
-syn match       asyNumbers       display transparent "\<\d\|\.\d" contains=asyNumber,asyFloat
-syn match       asyNumber        display contained "\d\+"
-"floating point number, with dot, optional exponent
-syn match       asyFloat         display contained "\d\+\.\d*\(e[-+]\=\d\+\)\="
-"floating point number, starting with a dot, optional exponent
-syn match       asyFloat         display contained "\.\d\+\(e[-+]\=\d\+\)\="
-"floating point number, without dot, with exponent
-syn match       asyFloat         display contained "\d\+e[-+]\=\d\+"
-syn case match
-
-if exists("asy_comment_strings")
-  " A comment can contain asyString, asyCString, asyCharacter and asyNumber.
-  " But a "*/" inside a asy*String in a asyComment DOES end the comment!  So we
-  " need to use a special type of asy*String: asyCommentString, which also ends on
-  " "*/", and sees a "*" at the start of the line as comment again.
-  " Unfortunately this doesn't very well work for // type of comments :-(
-  syn match     asyCommentSkip       contained "^\s*\*\($\|\s\+\)"
-  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCSpecial,asyCommentSkip
-  syn region    asyCommentLString    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial,asyCSpecial
-  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyCommentLString,asyCharacter,asyNumbersCom,asySpaceError
-  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyCharacter,asyNumbersCom,asySpaceError
-else
-  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asySpaceError
-  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asySpaceError
-endif
-" keep a // comment separately, it terminates a preproc. conditional
-syn match       asyCommentError      display "\*/"
-syn match       asyCommentStartError display "/\*"me=e-1 contained
-
-syn keyword     asyType          void bool bool3 int real string file
-syn keyword     asyType          pair triple transform guide path pen frame
-syn keyword     asyType          picture
-
-syn keyword     asyStructure     struct typedef
-syn keyword     asyStorageClass  static public restricted private explicit
-
-syn keyword     asyPathSpec      and cycle controls tension atleast curl
-
+" basic asymptote keywords
 syn keyword     asyConstant      VERSION
 syn keyword     asyConstant      true false default infinity inf nan
 syn keyword     asyConstant      null nullframe nullpath nullpen
 syn keyword     asyConstant      intMin intMax realMin realMax
 syn keyword     asyConstant      realEpsilon realDigits
+syn keyword     asyPathSpec      and cycle controls tension atleast curl
+syn keyword     asyStorageClass  static public restricted private explicit
+syn keyword     asyStructure     struct typedef
+syn keyword     asyType          void bool bool3 int real string file
+syn keyword     asyType          pair triple transform guide path pen frame
+syn keyword     asyType          picture
 
+" module specific keywords
 if exists("asy_syn_plain")
   syn keyword   asyConstant      currentpicture currentpen defaultpen
   syn keyword   asyConstant      inch inches cm mm bp pt up down right left
@@ -134,7 +68,7 @@ if exists("asy_syn_plain")
   syn keyword   asyConstant      olive darkbrown pink palegrey lightgrey
   syn keyword   asyConstant      mediumgrey grey heavygrey deepgrey darkgrey
 
-  if exists("asy_texcolors")
+  if exists("asy_syn_texcolors")
     syn keyword asyConstant      GreenYellow Yellow Goldenrod Dandelion
     syn keyword asyConstant      Apricot Peach Melon YellowOrange Orange
     syn keyword asyConstant      BurntOrange Bittersweet RedOrange Mahogany
@@ -153,7 +87,7 @@ if exists("asy_syn_plain")
     syn keyword asyConstant      Black White
   endif
 
-  if exists("asy_x11colors")
+  if exists("asy_syn_x11colors")
     syn keyword asyConstant      AliceBlue AntiqueWhite Aqua Aquamarine Azure
     syn keyword asyConstant      Beige Bisque Black BlanchedAlmond Blue
     syn keyword asyConstant      BlueViolet Brown BurlyWood CadetBlue
@@ -203,8 +137,74 @@ if exists("asy_syn_plain")
   endif
 endif
 
+" string constants
+syn region      asyCString       start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=asyCSpecial
+syn match       asyCSpecial      display contained +\\\(['"?\\abfnrtv]\|\o\{1,3}\|x[0-9A-F]\{1,2\}\|$\)+
+" double quoted strings only special character is \"
+syn region      asyString        start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=asySpecial
+syn match       asySpecial       display contained +[^\\]\(\\\\\)*\zs\\"+
+
+" number constants
+syn case ignore
+syn match       asyNumbers       display transparent "\<\d\|\.\d" contains=asyNumber,asyFloat
+"integer number, or floating point number without a dot and with "f".
+syn match       asyNumber        display contained "\d\+"
+"floating point number, with dot, optional exponent
+syn match       asyFloat         display contained "\d\+\.\d*\(e[-+]\=\d\+\)\="
+"floating point number, starting with a dot, optional exponent
+syn match       asyFloat         display contained "\.\d\+\(e[-+]\=\d\+\)\="
+"floating point number, without dot, with exponent
+syn match       asyFloat         display contained "\d\+e[-+]\=\d\+"
+syn case match
+
+" comments and comment strings
+if exists("asy_comment_strings")
+  " A comment can contain asyString, asyCString, asyCharacter and asyNumber.
+  " But a "*/" inside a asy*String in a asyComment DOES end the comment!  So we
+  " need to use a special type of asy*String: asyCommentString, which also ends on
+  " "*/", and sees a "*" at the start of the line as comment again.
+  " Unfortunately this doesn't very well work for // type of comments :-(
+  syn match     asyCommentSkip       contained "^\s*\*\($\|\s\+\)"
+  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCSpecial,asyCommentSkip
+  syn region    asyCommentLString    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial,asyCSpecial
+  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyCommentLString,asyCharacter,asyNumbersCom,asySpaceError
+  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyCharacter,asyNumbersCom,asySpaceError
+else
+  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asySpaceError
+  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asySpaceError
+endif
+
+" highlight common errors when starting/ending C comments
+syn match       asyCommentError      display "\*/"
+syn match       asyCommentStartError display "/\*"me=e-1 contained
+
+" asyCommentGroup allows adding matches for special things in comments
+syn cluster     asyCommentGroup  contains=asyTodo
+syn keyword     asyTodo          contained TODO FIXME XXX
 
 syn sync ccomment asyComment minlines=15
+
+" delimiter matching errors
+syn cluster     asyParenGroup    contains=asyParenError,asyIncluded,asySpecial,asyCSpecial,asyCommentSkip,asyCommentString,asyCommentLString,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
+if exists("asy_no_bracket_error")
+  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyCppString
+  " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
+  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString,asyCString
+  syn match     asyParenError    display ")"
+  syn match     asyErrInParen    display contained "[{}]"
+else
+  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyErrInBracket,asyCppBracket,asyCppString
+  " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
+  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString,asyCString
+if 0
+  syn match     asyParenError    display "[\])]"
+  syn match     asyErrInParen    display contained "[\]]"
+endif
+  syn region    asyBracket       transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen,asyCppParen,asyCppBracket,asyCppString
+  " asyCppBracket: same as asyParen but ends at end-of-line; used in asyDefine
+  syn region    asyCppBracket    transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString,asyCString
+  syn match     asyErrInBracket  display contained "[);]"
+endif
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -158,24 +158,22 @@ if exists("asy_comment_strings")
   " "*/", and sees a "*" at the start of the line as comment again.
   " Unfortunately this doesn't very well work for // type of comments :-(
   syn match     asyCommentSkip       contained "^\s*\*\($\|\s\+\)"
-  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCommentSkip
-  syn region    asyCommentCString    contained start=+L\='+ skip=+\\\\\|\\'+ end=+'+ end=+\*/+me=s-1 contains=asyCSpecial,asyCommentSkip
-  syn region    asyCommentLString    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial
-  syn region    asyCommentLCString   contained start=+L\='+ skip=+\\\\\|\\'+ end=+'+ end="$" contains=asyCSpecial
-  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyCommentLString,asyCommentLCString,asyNumbers
-  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyCommentCString,asyNumbers
+  syn region    asyCommentString     contained start=+"+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCommentSkip
+  syn region    asyCommentCString    contained start=+'+ skip=+\\\\\|\\'+ end=+'+ end=+\*/+me=s-1 contains=asyCSpecial,asyCommentSkip
+  syn region    asyCommentLString    contained start=+"+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial
+  syn region    asyCommentLCString   contained start=+'+ skip=+\\\\\|\\'+ end=+'+ end="$" contains=asyCSpecial
+  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=asyTodo,asyCommentLString,asyCommentLCString,asyNumbers
+  syn region    asyComment           matchgroup=asyComment start="/\*" end="\*/" contains=asyTodo,asyCommentStartError,asyCommentString,asyCommentCString,asyNumbers
 else
-  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup
-  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError
+  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=asyTodo
+  syn region    asyComment           matchgroup=asyComment start="/\*" end="\*/" contains=asyTodo,asyCommentStartError
 endif
 
 " highlight common errors when starting/ending C comments
 syn match       asyCommentError      display "\*/"
 syn match       asyCommentStartError display "/\*"me=e-1 contained
 
-" asyCommentGroup allows adding matches for special things in comments
-syn cluster     asyCommentGroup  contains=asyTodo
-syn keyword     asyTodo          contained TODO FIXME XXX
+syn keyword     asyTodo              contained TODO FIXME XXX
 
 syn sync ccomment asyComment minlines=15
 
@@ -207,7 +205,6 @@ if version >= 508 || !exists("did_asy_syn_inits")
   endif
 
   HiLink asyCommentL             asyComment
-  HiLink asyCommentStart         asyComment
   HiLink asyConditional          Conditional
   HiLink asyRepeat               Repeat
   HiLink asyNumber               Number

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -15,16 +15,16 @@ elseif exists("b:current_syntax")
 endif
 
 " A bunch of useful C keywords
-syn keyword     asyStatement    break return continue unravel
-syn keyword     asyConditional  if else
-syn keyword     asyRepeat       while for do
-syn keyword     asyExternal     access from import include
-syn keyword     asyOperator     new operator
+syn keyword     asyStatement     break return continue unravel
+syn keyword     asyConditional   if else
+syn keyword     asyRepeat        while for do
+syn keyword     asyExternal      access from import include
+syn keyword     asyOperator      new operator
 
-syn keyword     asyTodo         contained TODO FIXME XXX
+syn keyword     asyTodo          contained TODO FIXME XXX
 
 " asyCommentGroup allows adding matches for special things in comments
-syn cluster     asyCommentGroup contains=asyTodo
+syn cluster     asyCommentGroup  contains=asyTodo
 
 " String and Character constants
 syn region      asyString        start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=asySpecial
@@ -36,45 +36,45 @@ syn match       asyDoubleSpecial display contained +[^\\]\(\\\\\)*\zs\\"+
 "when wanted, highlight trailing white space
 if exists("asy_space_errors")
   if !exists("asy_no_trail_space_error")
-    syn match   asySpaceError   display excludenl "\s\+$"
+    syn match   asySpaceError    display excludenl "\s\+$"
   endif
   if !exists("asy_no_tab_space_error")
-    syn match   asySpaceError   display " \+\t"me=e-1
+    syn match   asySpaceError    display " \+\t"me=e-1
   endif
 endif
 
 "catch errors caused by wrong parenthesis and brackets
-syn cluster     asyParenGroup   contains=asyParenError,asyIncluded,asySpecial,asyDoubleSpecial,asyCommentSkip,asyCommentString,asyComment2String,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
+syn cluster     asyParenGroup    contains=asyParenError,asyIncluded,asySpecial,asyDoubleSpecial,asyCommentSkip,asyCommentString,asyComment2String,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
 if exists("asy_no_bracket_error")
-  syn region    asyParen        transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyCppString
+  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyCppString
   " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppParen     transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString,asyDoubleString
-  syn match     asyParenError   display ")"
-  syn match     asyErrInParen   display contained "[{}]"
+  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString,asyDoubleString
+  syn match     asyParenError    display ")"
+  syn match     asyErrInParen    display contained "[{}]"
 else
-  syn region    asyParen        transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyErrInBracket,asyCppBracket,asyCppString
+  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyErrInBracket,asyCppBracket,asyCppString
   " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppParen     transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString,asyDoubleString
+  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString,asyDoubleString
 if 0
-  syn match     asyParenError   display "[\])]"
-  syn match     asyErrInParen   display contained "[\]]"
+  syn match     asyParenError    display "[\])]"
+  syn match     asyErrInParen    display contained "[\]]"
 endif
-  syn region    asyBracket      transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen,asyCppParen,asyCppBracket,asyCppString
+  syn region    asyBracket       transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen,asyCppParen,asyCppBracket,asyCppString
   " asyCppBracket: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppBracket   transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString,asyDoubleString
-  syn match     asyErrInBracket display contained "[);]"
+  syn region    asyCppBracket    transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString,asyDoubleString
+  syn match     asyErrInBracket  display contained "[);]"
 endif
 
 "integer number, or floating point number without a dot and with "f".
 syn case ignore
-syn match       asyNumbers      display transparent "\<\d\|\.\d" contains=asyNumber,asyFloat
-syn match       asyNumber       display contained "\d\+"
+syn match       asyNumbers       display transparent "\<\d\|\.\d" contains=asyNumber,asyFloat
+syn match       asyNumber        display contained "\d\+"
 "floating point number, with dot, optional exponent
-syn match       asyFloat        display contained "\d\+\.\d*\(e[-+]\=\d\+\)\="
+syn match       asyFloat         display contained "\d\+\.\d*\(e[-+]\=\d\+\)\="
 "floating point number, starting with a dot, optional exponent
-syn match       asyFloat        display contained "\.\d\+\(e[-+]\=\d\+\)\="
+syn match       asyFloat         display contained "\.\d\+\(e[-+]\=\d\+\)\="
 "floating point number, without dot, with exponent
-syn match       asyFloat        display contained "\d\+e[-+]\=\d\+"
+syn match       asyFloat         display contained "\d\+e[-+]\=\d\+"
 syn case match
 
 if exists("asy_comment_strings")
@@ -96,39 +96,39 @@ endif
 syn match       asyCommentError      display "\*/"
 syn match       asyCommentStartError display "/\*"me=e-1 contained
 
-syn keyword     asyType         void bool int real string file
-syn keyword     asyType         pair triple transform guide path pen frame
-syn keyword     asyType         picture
+syn keyword     asyType          void bool int real string file
+syn keyword     asyType          pair triple transform guide path pen frame
+syn keyword     asyType          picture
 
-syn keyword     asyStructure    struct typedef
-syn keyword     asyStorageClass static public restricted private explicit
+syn keyword     asyStructure     struct typedef
+syn keyword     asyStorageClass  static public restricted private explicit
 
-syn keyword     asyPathSpec     and cycle controls tension atleast curl
+syn keyword     asyPathSpec      and cycle controls tension atleast curl
 
-syn keyword     asyConstant     true false default infinity inf
-syn keyword     asyConstant     null nullframe nullpath nullpen
+syn keyword     asyConstant      true false default infinity inf
+syn keyword     asyConstant      null nullframe nullpath nullpen
 
 if exists("asy_syn_plain")
-  syn keyword   asyConstant     currentpicture currentpen currentprojection
-  syn keyword   asyConstant     inch inches cm mm bp pt up down right left
-  syn keyword   asyConstant     E NE N NW W SW S SE
-  syn keyword   asyConstant     ENE NNE NNW WNW WSW SSW SSE ESE
-  syn keyword   asyConstant     I pi twopi
-  syn keyword   asyConstant     identity zeroTransform
-  syn keyword   asyConstant     solid dotted dashed dashdotted
-  syn keyword   asyConstant     longdashed longdashdotted
-  syn keyword   asyConstant     squarecap roundcap extendcap
-  syn keyword   asyConstant     miterjoin roundjoin beveljoin
-  syn keyword   asyConstant     zerowinding evenodd
-  syn keyword   asyConstant     invisible black gray grey white
-  syn keyword   asyConstant     lightgray lightgrey
-  syn keyword   asyConstant     red green blue
-  syn keyword   asyConstant     cmyk Cyan Magenta Yellow Black
-  syn keyword   asyConstant     yellow magenta cyan
-  syn keyword   asyConstant     brown darkgreen darkblue
-  syn keyword   asyConstant     orange purple royalblue olive
-  syn keyword   asyConstant     chartreuse fuchsia salmon lightblue
-  syn keyword   asyConstant     springgreen pink
+  syn keyword   asyConstant      currentpicture currentpen currentprojection
+  syn keyword   asyConstant      inch inches cm mm bp pt up down right left
+  syn keyword   asyConstant      E NE N NW W SW S SE
+  syn keyword   asyConstant      ENE NNE NNW WNW WSW SSW SSE ESE
+  syn keyword   asyConstant      I pi twopi
+  syn keyword   asyConstant      identity zeroTransform
+  syn keyword   asyConstant      solid dotted dashed dashdotted
+  syn keyword   asyConstant      longdashed longdashdotted
+  syn keyword   asyConstant      squarecap roundcap extendcap
+  syn keyword   asyConstant      miterjoin roundjoin beveljoin
+  syn keyword   asyConstant      zerowinding evenodd
+  syn keyword   asyConstant      invisible black gray grey white
+  syn keyword   asyConstant      lightgray lightgrey
+  syn keyword   asyConstant      red green blue
+  syn keyword   asyConstant      cmyk Cyan Magenta Yellow Black
+  syn keyword   asyConstant      yellow magenta cyan
+  syn keyword   asyConstant      brown darkgreen darkblue
+  syn keyword   asyConstant      orange purple royalblue olive
+  syn keyword   asyConstant      chartreuse fuchsia salmon lightblue
+  syn keyword   asyConstant      springgreen pink
 endif
 
 syn sync ccomment asyComment minlines=15
@@ -144,53 +144,53 @@ if version >= 508 || !exists("did_asy_syn_inits")
     command -nargs=+ HiLink hi def link <args>
   endif
 
-  HiLink asyFormat              asySpecial
-  HiLink asyCppString           asyString
-  HiLink asyCommentL            asyComment
-  HiLink asyCommentStart        asyComment
-  HiLink asyLabel               Label
-  HiLink asyUserLabel           Label
-  HiLink asyConditional         Conditional
-  HiLink asyRepeat              Repeat
-  HiLink asyCharacter           Character
-  HiLink asySpecialCharacter    asySpecial
-  HiLink asyNumber              Number
-  HiLink asyOctal               Number
-  HiLink asyOctalZero           PreProc  " link this to Error if you want
-  HiLink asyFloat               Float
-  HiLink asyOctalError          asyError
-  HiLink asyParenError          asyError
-  HiLink asyErrInParen          asyError
-  HiLink asyErrInBracket        asyError
-  HiLink asyCommentError        asyError
-  HiLink asyCommentStartError   asyError
-  HiLink asySpaceError          asyError
-  HiLink asySpecialError        asyError
-  HiLink asyOperator            Operator
-  HiLink asyStructure           Structure
-  HiLink asyStorageClass        StorageClass
-  HiLink asyExternal            Include
-  HiLink asyPreProc             PreProc
-  HiLink asyDefine              Macro
-  HiLink asyIncluded            asyString
-  HiLink asyError               Error
-  HiLink asyStatement           Statement
-  HiLink asyPreCondit           PreCondit
-  HiLink asyType                Type
-  HiLink asyConstant            Constant
-  HiLink asyCommentString       asyString
-  HiLink asyComment2String      asyString
-  HiLink asyCommentSkip         asyComment
-  HiLink asyString              String
-  HiLink asyDoubleString        String
-  HiLink asyComment             Comment
-  HiLink asySpecial             SpecialChar
-  HiLink asyDoubleSpecial       SpecialChar
-  HiLink asyTodo                Todo
-  HiLink asyCppSkip             asyCppOut
-  HiLink asyCppOut2             asyCppOut
-  HiLink asyCppOut              Comment
-  HiLink asyPathSpec            Statement
+  HiLink asyFormat               asySpecial
+  HiLink asyCppString            asyString
+  HiLink asyCommentL             asyComment
+  HiLink asyCommentStart         asyComment
+  HiLink asyLabel                Label
+  HiLink asyUserLabel            Label
+  HiLink asyConditional          Conditional
+  HiLink asyRepeat               Repeat
+  HiLink asyCharacter            Character
+  HiLink asySpecialCharacter     asySpecial
+  HiLink asyNumber               Number
+  HiLink asyOctal                Number
+  HiLink asyOctalZero            PreProc  " link this to Error if you want
+  HiLink asyFloat                Float
+  HiLink asyOctalError           asyError
+  HiLink asyParenError           asyError
+  HiLink asyErrInParen           asyError
+  HiLink asyErrInBracket         asyError
+  HiLink asyCommentError         asyError
+  HiLink asyCommentStartError    asyError
+  HiLink asySpaceError           asyError
+  HiLink asySpecialError         asyError
+  HiLink asyOperator             Operator
+  HiLink asyStructure            Structure
+  HiLink asyStorageClass         StorageClass
+  HiLink asyExternal             Include
+  HiLink asyPreProc              PreProc
+  HiLink asyDefine               Macro
+  HiLink asyIncluded             asyString
+  HiLink asyError                Error
+  HiLink asyStatement            Statement
+  HiLink asyPreCondit            PreCondit
+  HiLink asyType                 Type
+  HiLink asyConstant             Constant
+  HiLink asyCommentString        asyString
+  HiLink asyComment2String       asyString
+  HiLink asyCommentSkip          asyComment
+  HiLink asyString               String
+  HiLink asyDoubleString         String
+  HiLink asyComment              Comment
+  HiLink asySpecial              SpecialChar
+  HiLink asyDoubleSpecial        SpecialChar
+  HiLink asyTodo                 Todo
+  HiLink asyCppSkip              asyCppOut
+  HiLink asyCppOut2              asyCppOut
+  HiLink asyCppOut               Comment
+  HiLink asyPathSpec             Statement
 
   delcommand HiLink
 endif

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -142,7 +142,7 @@ syn region      asyCString       start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=asy
 syn match       asyCSpecial      display contained +\\\(['"?\\abfnrtv]\|\o\{1,3}\|x[0-9A-F]\{1,2\}\|$\)+
 " double quoted strings only special character is \"
 syn region      asyString        start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=asySpecial
-syn match       asySpecial       display contained +[^\\]\(\\\\\)*\zs\\"+
+syn match       asySpecial       display contained +\(\\\)\@1<!\(\\\\\)*\zs\\"+
 
 " number constants
 syn case ignore

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Asymptote
 " Maintainer:   Andy Hammerlindl
-" Last Change:  2005 Aug 23
+" Last Change:  2022 Jan 05
 
 " Hacked together from Bram Moolenaar's C syntax file, and Claudio Fleiner's
 " Java syntax file.
@@ -137,55 +137,79 @@ if exists("asy_syn_plain")
   endif
 endif
 
+
 " string constants
-syn region      asyCString       start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=asyCSpecial
-syn match       asyCSpecial      display contained +\\\(['"?\\abfnrtv]\|\o\{1,3}\|x[0-9A-F]\{1,2\}\|$\)+
+syn region asyCString start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=asyCSpecial
+syn match  asyCSpecial display contained +\\\(['"?\\abfnrtv]\|\o\{1,3}\)+
+syn match  asyCSpecial display contained +\\\(x[0-9A-F]\{1,2\}\|$\)+
 " double quoted strings only special character is \"
-syn region      asyString        start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=asySpecial
-syn match       asySpecial       display contained +\(\\\)\@1<!\(\\\\\)*\zs\\"+
+syn region asyString   start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=asySpecial
+syn match  asySpecial  display contained +\(\\\)\@1<!\(\\\\\)*\zs\\"+
+
 
 " number constants
-syn match       asyNumbers       display transparent "\<\d\|\.\d" contains=asyNumber,asyNumberError
-syn match       asyNumber        display contained "\d*\.\=\d*\(e[-+]\=\d\+\)\="
+syn match  asyNumbers     display transparent "\<\d\|\.\d"
+                        \ contains=asyNumber,asyNumberError
+syn match  asyNumber      display contained "\d*\.\=\d*\(e[-+]\=\d\+\)\="
 " highlight number constants with two '.' or with '.' after an 'e'
-syn match       asyNumberError   display contained "\d*\(\.\|e[-+]\=\)\(\d\|e[-+]\=\)*\.[0-9.]*"
+syn match  asyNumberError display contained "\d*\.\(\d\|e[-+]\=\)*\.[0-9.]*"
+syn match  asyNumberError display contained "\d*e[-+]\=\d*\.[0-9.]*"
+syn match  asyNumberError display contained "\d*e[-+]\=\(e[-+]\=\)*\.[0-9.]*"
+
 
 " comments and comment strings
+syn keyword  asyTodo            contained TODO FIXME XXX
+syn sync     ccomment           asyComment minlines=15
 if exists("asy_comment_strings")
-  " A comment can contain asyString, asyCString, and asyNumber.
-  " But a "*/" inside a asy*String in a asyComment DOES end the comment!  So we
-  " need to use a special type of asy*String: asyCommentString, which also ends on
+  " A comment can contain asyString, asyCString, and asyNumber. But a "*/"
+  " inside a asy*String in a asyComment DOES end the comment!  So we need to
+  " use a special type of asy*String: asyComment*String, which also ends on
   " "*/", and sees a "*" at the start of the line as comment again.
   " Unfortunately this doesn't very well work for // type of comments :-(
-  syn match     asyCommentSkip       contained "^\s*\*\($\|\s\+\)"
-  syn region    asyCommentString     contained start=+"+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCommentSkip
-  syn region    asyCommentCString    contained start=+'+ skip=+\\\\\|\\'+ end=+'+ end=+\*/+me=s-1 contains=asyCSpecial,asyCommentSkip
-  syn region    asyCommentLString    contained start=+"+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial
-  syn region    asyCommentLCString   contained start=+'+ skip=+\\\\\|\\'+ end=+'+ end="$" contains=asyCSpecial
-  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=asyTodo,asyCommentLString,asyCommentLCString,asyNumbers
-  syn region    asyComment           matchgroup=asyComment start="/\*" end="\*/" contains=asyTodo,asyCommentStartError,asyCommentString,asyCommentCString,asyNumbers
+  syn match  asyCommentSkip     contained "^\s*\*\($\|\s\+\)"
+  syn region asyCommentString   contained start=+"+ skip=+\\\\\|\\"+ end=+"+
+                              \ end=+\*/+me=s-1
+                              \ contains=asySpecial,asyCommentSkip
+  syn region asyCommentCString  contained start=+'+ skip=+\\\\\|\\'+ end=+'+
+                              \ end=+\*/+me=s-1
+                              \ contains=asyCSpecial,asyCommentSkip
+  syn region asyCommentLString  contained start=+"+ skip=+\\\\\|\\"+ end=+"+
+                              \ end="$" contains=asySpecial
+  syn region asyCommentLCString contained start=+'+ skip=+\\\\\|\\'+ end=+'+
+                              \ end="$" contains=asyCSpecial
+  syn region asyCommentL        start="//" skip="\\$" end="$" keepend
+                              \ contains=asyTodo,asyCommentLString,
+                              \ asyCommentLCString,asyNumbers
+  syn region asyComment         matchgroup=asyComment start="/\*" end="\*/"
+                              \ contains=asyTodo,asyCommentStartError,
+                              \ asyCommentString,asyCommentCString,asyNumbers
 else
-  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=asyTodo
-  syn region    asyComment           matchgroup=asyComment start="/\*" end="\*/" contains=asyTodo,asyCommentStartError
+  syn region asyCommentL        start="//" skip="\\$" end="$" keepend
+                              \ contains=asyTodo
+  syn region asyComment         matchgroup=asyComment start="/\*" end="\*/"
+                              \ contains=asyTodo,asyCommentStartError
 endif
 
 " highlight common errors when starting/ending C comments
-syn match       asyCommentError      display "\*/"
-syn match       asyCommentStartError display "/\*"me=e-1 contained
+syn match    asyCommentError      display "\*/"
+syn match    asyCommentStartError display "/\*"me=e-1 contained
 
-syn keyword     asyTodo              contained TODO FIXME XXX
-
-syn sync ccomment asyComment minlines=15
 
 " delimiter matching errors
-syn region asyCurly      transparent start='{'  end='}'  contains=TOP,asyCurlyError
-syn region asyBrack      transparent start='\[' end='\]' matchgroup=asyError end=';' contains=TOP,asyBrackError
-syn region asyParen      transparent start='('  end=')'  matchgroup=asyError end=';' contains=TOP,asyParenError
+syn region asyCurly      transparent start='{'  end='}'
+                       \ contains=TOP,asyCurlyError
+syn region asyBrack      transparent start='\[' end='\]' matchgroup=asyError
+                       \ end=';' contains=TOP,asyBrackError
+syn region asyParen      transparent start='('  end=')'  matchgroup=asyError
+                       \ end=';' contains=TOP,asyParenError
 syn match  asyCurlyError display '}'
 syn match  asyBrackError display '\]'
 syn match  asyParenError display ')'
 " for (;;) constructs are exceptions that allow ; inside parenthesis
-syn region asyParen      transparent matchgroup=asyParen start='\(for\s*\)\@<=(' end=')' contains=TOP,asyParenError
+syn region asyParen      transparent matchgroup=asyParen
+                       \ start='\(for\s*\)\@<=(' end=')'
+                       \ contains=TOP,asyParenError
+
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
-" Language:	Asymptote
-" Maintainer:	Andy Hammerlindl
-" Last Change:	2005 Aug 23
+" Language:     Asymptote
+" Maintainer:   Andy Hammerlindl
+" Last Change:  2005 Aug 23
 
 " Hacked together from Bram Moolenaar's C syntax file, and Claudio Fleiner's
 " Java syntax file.
@@ -9,76 +9,76 @@
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
 if version < 600
-  syntax clear
+  syn clear
 elseif exists("b:current_syntax")
   finish
 endif
 
 " A bunch of useful C keywords
-syn keyword	asyStatement	break return continue unravel
-syn keyword	asyConditional	if else
-syn keyword	asyRepeat	while for do
+syn keyword     asyStatement    break return continue unravel
+syn keyword     asyConditional  if else
+syn keyword     asyRepeat       while for do
 syn keyword     asyExternal     access from import include
 syn keyword     asyOperator     new operator
 
-syn keyword	asyTodo		contained TODO FIXME XXX
+syn keyword     asyTodo         contained TODO FIXME XXX
 
 " asyCommentGroup allows adding matches for special things in comments
-syn cluster	asyCommentGroup	contains=asyTodo
+syn cluster     asyCommentGroup contains=asyTodo
 
 " String and Character constants
 " Highlight special characters (those proceding a double backslash) differently
-syn match	asySpecial	display contained "\\\\."
+syn match       asySpecial      display contained "\\\\."
 " Highlight line continuation slashes
-syn match	asySpecial	display contained "\\$"
-syn region	asyString	start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=asySpecial
+syn match       asySpecial      display contained "\\$"
+syn region      asyString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=asySpecial
   " asyCppString: same as asyString, but ends at end of line
 if 0
-syn region	asyCppString	start=+"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=asySpecial
+syn region      asyCppString    start=+"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=asySpecial
 endif
 
 "when wanted, highlight trailing white space
 if exists("asy_space_errors")
   if !exists("asy_no_trail_space_error")
-    syn match	asySpaceError	display excludenl "\s\+$"
+    syn match   asySpaceError   display excludenl "\s\+$"
   endif
   if !exists("asy_no_tab_space_error")
-    syn match	asySpaceError	display " \+\t"me=e-1
+    syn match   asySpaceError   display " \+\t"me=e-1
   endif
 endif
 
 "catch errors caused by wrong parenthesis and brackets
-syn cluster	asyParenGroup	contains=asyParenError,asyIncluded,asySpecial,asyCommentSkip,asyCommentString,asyComment2String,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
+syn cluster     asyParenGroup   contains=asyParenError,asyIncluded,asySpecial,asyCommentSkip,asyCommentString,asyComment2String,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
 if exists("asy_no_bracket_error")
-  syn region	asyParen		transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyCppString
+  syn region    asyParen        transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyCppString
   " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region	asyCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString
-  syn match	asyParenError	display ")"
-  syn match	asyErrInParen	display contained "[{}]"
+  syn region    asyCppParen     transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString
+  syn match     asyParenError   display ")"
+  syn match     asyErrInParen   display contained "[{}]"
 else
-  syn region	asyParen	transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyErrInBracket,asyCppBracket,asyCppString
+  syn region    asyParen        transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyErrInBracket,asyCppBracket,asyCppString
   " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region	asyCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString
+  syn region    asyCppParen     transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString
 if 0
-  syn match	asyParenError	display "[\])]"
-  syn match	asyErrInParen	display contained "[\]]"
+  syn match     asyParenError   display "[\])]"
+  syn match     asyErrInParen   display contained "[\]]"
 endif
-  syn region	asyBracket	transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen,asyCppParen,asyCppBracket,asyCppString
+  syn region    asyBracket      transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen,asyCppParen,asyCppBracket,asyCppString
   " asyCppBracket: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region	asyCppBracket	transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString
-  syn match	asyErrInBracket	display contained "[);]"
+  syn region    asyCppBracket   transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString
+  syn match     asyErrInBracket display contained "[);]"
 endif
 
 "integer number, or floating point number without a dot and with "f".
 syn case ignore
-syn match	asyNumbers	display transparent "\<\d\|\.\d" contains=asyNumber,asyFloat
+syn match       asyNumbers      display transparent "\<\d\|\.\d" contains=asyNumber,asyFloat
 syn match       asyNumber       display contained "\d\+"
 "floating point number, with dot, optional exponent
-syn match	asyFloat	display contained "\d\+\.\d*\(e[-+]\=\d\+\)\="
+syn match       asyFloat        display contained "\d\+\.\d*\(e[-+]\=\d\+\)\="
 "floating point number, starting with a dot, optional exponent
-syn match	asyFloat	display contained "\.\d\+\(e[-+]\=\d\+\)\="
+syn match       asyFloat        display contained "\.\d\+\(e[-+]\=\d\+\)\="
 "floating point number, without dot, with exponent
-syn match	asyFloat	display contained "\d\+e[-+]\=\d\+"
+syn match       asyFloat        display contained "\d\+e[-+]\=\d\+"
 syn case match
 
 if exists("asy_comment_strings")
@@ -87,24 +87,24 @@ if exists("asy_comment_strings")
   " need to use a special type of asyString: asyCommentString, which also ends on
   " "*/", and sees a "*" at the start of the line as comment again.
   " Unfortunately this doesn't very well work for // type of comments :-(
-  syntax match	asyCommentSkip	contained "^\s*\*\($\|\s\+\)"
-  syntax region asyCommentString	contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCommentSkip
-  syntax region asyComment2String	contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial
-  syntax region  asyCommentL	start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyComment2String,asyCharacter,asyNumbersCom,asySpaceError
-  syntax region asyComment	matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyCharacter,asyNumbersCom,asySpaceError
+  syn match     asyCommentSkip       contained "^\s*\*\($\|\s\+\)"
+  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCommentSkip
+  syn region    asyComment2String    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial
+  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyComment2String,asyCharacter,asyNumbersCom,asySpaceError
+  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyCharacter,asyNumbersCom,asySpaceError
 else
-  syn region	asyCommentL	start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asySpaceError
-  syn region	asyComment	matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asySpaceError
+  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asySpaceError
+  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asySpaceError
 endif
 " keep a // comment separately, it terminates a preproc. conditional
-syntax match	asyCommentError	display "\*/"
-syntax match	asyCommentStartError display "/\*"me=e-1 contained
+syn match       asyCommentError      display "\*/"
+syn match       asyCommentStartError display "/\*"me=e-1 contained
 
-syn keyword	asyType		void bool int real string
-syn keyword	asyType		pair triple transform guide path pen frame
+syn keyword     asyType         void bool int real string
+syn keyword     asyType         pair triple transform guide path pen frame
 syn keyword     asyType         picture
 
-syn keyword	asyStructure	struct typedef
+syn keyword     asyStructure    struct typedef
 syn keyword     asyStorageClass static public readable private explicit
 
 syn keyword     asyPathSpec     and cycle controls tension atleast curl
@@ -113,25 +113,25 @@ syn keyword     asyConstant     true false
 syn keyword     asyConstant     null nullframe nullpath
 
 if exists("asy_syn_plain")
-  syn keyword	asyConstant	currentpicture currentpen currentprojection
-  syn keyword	asyConstant	inch inches cm mm bp pt up down right left 
-  syn keyword	asyConstant	E NE N NW W SW S SE
-  syn keyword	asyConstant	ENE NNE NNW WNW WSW SSW SSE ESE
-  syn keyword	asyConstant	I pi twopi
-  syn keyword	asyConstant	solid dotted dashed dashdotted
-  syn keyword	asyConstant	longdashed longdashdotted
-  syn keyword	asyConstant	squarecap roundcap extendcap
-  syn keyword	asyConstant	miterjoin roundjoin beveljoin
-  syn keyword	asyConstant	zerowinding evenodd
-  syn keyword	asyConstant	invisible black gray grey white
-  syn keyword	asyConstant	lightgray lightgrey
-  syn keyword	asyConstant	red green blue
-  syn keyword	asyConstant	cmyk Cyan Magenta Yellow Black
-  syn keyword	asyConstant	yellow magenta cyan
-  syn keyword	asyConstant	brown darkgreen darkblue
-  syn keyword	asyConstant	orange purple royalblue olive
-  syn keyword	asyConstant	chartreuse fuchsia salmon lightblue springgreen
-  syn keyword	asyConstant	pink
+  syn keyword   asyConstant     currentpicture currentpen currentprojection
+  syn keyword   asyConstant     inch inches cm mm bp pt up down right left
+  syn keyword   asyConstant     E NE N NW W SW S SE
+  syn keyword   asyConstant     ENE NNE NNW WNW WSW SSW SSE ESE
+  syn keyword   asyConstant     I pi twopi
+  syn keyword   asyConstant     solid dotted dashed dashdotted
+  syn keyword   asyConstant     longdashed longdashdotted
+  syn keyword   asyConstant     squarecap roundcap extendcap
+  syn keyword   asyConstant     miterjoin roundjoin beveljoin
+  syn keyword   asyConstant     zerowinding evenodd
+  syn keyword   asyConstant     invisible black gray grey white
+  syn keyword   asyConstant     lightgray lightgrey
+  syn keyword   asyConstant     red green blue
+  syn keyword   asyConstant     cmyk Cyan Magenta Yellow Black
+  syn keyword   asyConstant     yellow magenta cyan
+  syn keyword   asyConstant     brown darkgreen darkblue
+  syn keyword   asyConstant     orange purple royalblue olive
+  syn keyword   asyConstant     chartreuse fuchsia salmon lightblue
+  syn keyword   asyConstant     springgreen pink
 endif
 
 syn sync ccomment asyComment minlines=15
@@ -147,56 +147,53 @@ if version >= 508 || !exists("did_asy_syn_inits")
     command -nargs=+ HiLink hi def link <args>
   endif
 
-  HiLink asyFormat		asySpecial
-  HiLink asyCppString		asyString
-  HiLink asyCommentL		asyComment
-  HiLink asyCommentStart		asyComment
-  HiLink asyLabel			Label
-  HiLink asyUserLabel		Label
-  HiLink asyConditional		Conditional
-  HiLink asyRepeat		Repeat
-  HiLink asyCharacter		Character
-  HiLink asySpecialCharacter	asySpecial
-  HiLink asyNumber		Number
-  HiLink asyOctal			Number
-  HiLink asyOctalZero		PreProc	 " link this to Error if you want
-  HiLink asyFloat			Float
-  HiLink asyOctalError		asyError
-  HiLink asyParenError		asyError
-  HiLink asyErrInParen		asyError
-  HiLink asyErrInBracket		asyError
-  HiLink asyCommentError		asyError
-  HiLink asyCommentStartError	asyError
-  HiLink asySpaceError		asyError
-  HiLink asySpecialError		asyError
-  HiLink asyOperator		Operator
-  HiLink asyStructure		Structure
-  HiLink asyStorageClass		StorageClass
-  HiLink asyExternal		Include
-  HiLink asyPreProc		PreProc
-  HiLink asyDefine		Macro
-  HiLink asyIncluded		asyString
-  HiLink asyError			Error
-  HiLink asyStatement		Statement
-  HiLink asyPreCondit		PreCondit
-  HiLink asyType			Type
-  HiLink asyConstant		Constant
-  HiLink asyCommentString		asyString
-  HiLink asyComment2String	asyString
-  HiLink asyCommentSkip		asyComment
-  HiLink asyString		String
-  HiLink asyComment		Comment
-  HiLink asySpecial		SpecialChar
-  HiLink asyTodo			Todo
-  HiLink asyCppSkip		asyCppOut
-  HiLink asyCppOut2		asyCppOut
-  HiLink asyCppOut		Comment
-  HiLink asyPathSpec		Statement
-		
+  HiLink asyFormat              asySpecial
+  HiLink asyCppString           asyString
+  HiLink asyCommentL            asyComment
+  HiLink asyCommentStart        asyComment
+  HiLink asyLabel               Label
+  HiLink asyUserLabel           Label
+  HiLink asyConditional         Conditional
+  HiLink asyRepeat              Repeat
+  HiLink asyCharacter           Character
+  HiLink asySpecialCharacter    asySpecial
+  HiLink asyNumber              Number
+  HiLink asyOctal               Number
+  HiLink asyOctalZero           PreProc  " link this to Error if you want
+  HiLink asyFloat               Float
+  HiLink asyOctalError          asyError
+  HiLink asyParenError          asyError
+  HiLink asyErrInParen          asyError
+  HiLink asyErrInBracket        asyError
+  HiLink asyCommentError        asyError
+  HiLink asyCommentStartError   asyError
+  HiLink asySpaceError          asyError
+  HiLink asySpecialError        asyError
+  HiLink asyOperator            Operator
+  HiLink asyStructure           Structure
+  HiLink asyStorageClass        StorageClass
+  HiLink asyExternal            Include
+  HiLink asyPreProc             PreProc
+  HiLink asyDefine              Macro
+  HiLink asyIncluded            asyString
+  HiLink asyError               Error
+  HiLink asyStatement           Statement
+  HiLink asyPreCondit           PreCondit
+  HiLink asyType                Type
+  HiLink asyConstant            Constant
+  HiLink asyCommentString       asyString
+  HiLink asyComment2String      asyString
+  HiLink asyCommentSkip         asyComment
+  HiLink asyString              String
+  HiLink asyComment             Comment
+  HiLink asySpecial             SpecialChar
+  HiLink asyTodo                Todo
+  HiLink asyCppSkip             asyCppOut
+  HiLink asyCppOut2             asyCppOut
+  HiLink asyCppOut              Comment
+  HiLink asyPathSpec            Statement
 
   delcommand HiLink
 endif
 
 let b:current_syntax = "c"
-
-" vim: ts=8

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -159,19 +159,19 @@ syn case match
 
 " comments and comment strings
 if exists("asy_comment_strings")
-  " A comment can contain asyString, asyCString, asyCharacter and asyNumber.
+  " A comment can contain asyString, asyCString, and asyNumber.
   " But a "*/" inside a asy*String in a asyComment DOES end the comment!  So we
   " need to use a special type of asy*String: asyCommentString, which also ends on
   " "*/", and sees a "*" at the start of the line as comment again.
   " Unfortunately this doesn't very well work for // type of comments :-(
   syn match     asyCommentSkip       contained "^\s*\*\($\|\s\+\)"
-  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCSpecial,asyCommentSkip
-  syn region    asyCommentLString    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial,asyCSpecial
-  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyCommentLString,asyCharacter,asyNumbersCom,asySpaceError
-  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyCharacter,asyNumbersCom,asySpaceError
+  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asyCSpecial,asyCommentSkip
+  syn region    asyCommentLString    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asyCSpecial
+  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyCommentLString,asyNumbers
+  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyNumbers
 else
-  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asySpaceError
-  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asySpaceError
+  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup
+  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError
 endif
 
 " highlight common errors when starting/ending C comments
@@ -185,24 +185,18 @@ syn keyword     asyTodo          contained TODO FIXME XXX
 syn sync ccomment asyComment minlines=15
 
 " delimiter matching errors
-syn cluster     asyParenGroup    contains=asyParenError,asyIncluded,asySpecial,asyCSpecial,asyCommentSkip,asyCommentString,asyCommentLString,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
+syn cluster     asyParenGroup    contains=asyParenError,asyCSpecial,asyCommentSkip,asyCommentString,asyCommentLString,@asyCommentGroup,asyCommentStartError,asyNumbers
 if exists("asy_no_bracket_error")
-  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyCppString
-  " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString,asyCString
+  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup
   syn match     asyParenError    display ")"
   syn match     asyErrInParen    display contained "[{}]"
 else
-  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyErrInBracket,asyCppBracket,asyCppString
-  " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString,asyCString
+  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyErrInBracket
 if 0
   syn match     asyParenError    display "[\])]"
   syn match     asyErrInParen    display contained "[\]]"
 endif
-  syn region    asyBracket       transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen,asyCppParen,asyCppBracket,asyCppString
-  " asyCppBracket: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppBracket    transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString,asyCString
+  syn region    asyBracket       transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen
   syn match     asyErrInBracket  display contained "[);]"
 endif
 
@@ -217,38 +211,24 @@ if version >= 508 || !exists("did_asy_syn_inits")
     command -nargs=+ HiLink hi def link <args>
   endif
 
-  HiLink asyFormat               asySpecial
-  HiLink asyCppString            asyString
   HiLink asyCommentL             asyComment
   HiLink asyCommentStart         asyComment
-  HiLink asyLabel                Label
-  HiLink asyUserLabel            Label
   HiLink asyConditional          Conditional
   HiLink asyRepeat               Repeat
-  HiLink asyCharacter            Character
-  HiLink asySpecialCharacter     asySpecial
   HiLink asyNumber               Number
-  HiLink asyOctal                Number
-  HiLink asyOctalZero            PreProc  " link this to Error if you want
   HiLink asyFloat                Float
-  HiLink asyOctalError           asyError
   HiLink asyParenError           asyError
   HiLink asyErrInParen           asyError
   HiLink asyErrInBracket         asyError
   HiLink asyCommentError         asyError
   HiLink asyCommentStartError    asyError
-  HiLink asySpaceError           asyError
-  HiLink asySpecialError         asyError
   HiLink asyOperator             Operator
   HiLink asyStructure            Structure
   HiLink asyStorageClass         StorageClass
   HiLink asyExternal             Include
-  HiLink asyPreProc              PreProc
   HiLink asyDefine               Macro
-  HiLink asyIncluded             asyString
   HiLink asyError                Error
   HiLink asyStatement            Statement
-  HiLink asyPreCondit            PreCondit
   HiLink asyType                 Type
   HiLink asyConstant             Constant
   HiLink asyCommentString        asyString
@@ -260,9 +240,6 @@ if version >= 508 || !exists("did_asy_syn_inits")
   HiLink asySpecial              SpecialChar
   HiLink asyCSpecial             SpecialChar
   HiLink asyTodo                 Todo
-  HiLink asyCppSkip              asyCppOut
-  HiLink asyCppOut2              asyCppOut
-  HiLink asyCppOut               Comment
   HiLink asyPathSpec             Statement
 
   delcommand HiLink

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -115,7 +115,7 @@ if exists("asy_syn_plain")
   syn keyword   asyConstant      ENE NNE NNW WNW WSW SSW SSE ESE
   syn keyword   asyConstant      I pi twopi
   syn keyword   asyConstant      identity zeroTransform
-  syn keyword   asyConstant      solid dotted dashed dashdotted
+  syn keyword   asyConstant      solid dotted Dotted dashed dashdotted
   syn keyword   asyConstant      longdashed longdashdotted
   syn keyword   asyConstant      squarecap roundcap extendcap
   syn keyword   asyConstant      miterjoin roundjoin beveljoin

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -145,17 +145,10 @@ syn region      asyString        start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=asy
 syn match       asySpecial       display contained +\(\\\)\@1<!\(\\\\\)*\zs\\"+
 
 " number constants
-syn case ignore
-syn match       asyNumbers       display transparent "\<\d\|\.\d" contains=asyNumber,asyFloat
-"integer number, or floating point number without a dot and with "f".
-syn match       asyNumber        display contained "\d\+"
-"floating point number, with dot, optional exponent
-syn match       asyFloat         display contained "\d\+\.\d*\(e[-+]\=\d\+\)\="
-"floating point number, starting with a dot, optional exponent
-syn match       asyFloat         display contained "\.\d\+\(e[-+]\=\d\+\)\="
-"floating point number, without dot, with exponent
-syn match       asyFloat         display contained "\d\+e[-+]\=\d\+"
-syn case match
+syn match       asyNumbers       display transparent "\<\d\|\.\d" contains=asyNumber,asyNumberError
+syn match       asyNumber        display contained "\d*\.\=\d*\(e[-+]\=\d\+\)\="
+" highlight number constants with two '.' or with '.' after an 'e'
+syn match       asyNumberError   display contained "\d*\(\.\|e[-+]\=\)\(\d\|e[-+]\=\)*\.[0-9.]*"
 
 " comments and comment strings
 if exists("asy_comment_strings")
@@ -218,7 +211,7 @@ if version >= 508 || !exists("did_asy_syn_inits")
   HiLink asyConditional          Conditional
   HiLink asyRepeat               Repeat
   HiLink asyNumber               Number
-  HiLink asyFloat                Float
+  HiLink asyNumberError          asyError
   HiLink asyParenError           asyError
   HiLink asyErrInParen           asyError
   HiLink asyErrInBracket         asyError

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -100,17 +100,17 @@ endif
 syn match       asyCommentError      display "\*/"
 syn match       asyCommentStartError display "/\*"me=e-1 contained
 
-syn keyword     asyType         void bool int real string
+syn keyword     asyType         void bool int real string file
 syn keyword     asyType         pair triple transform guide path pen frame
 syn keyword     asyType         picture
 
 syn keyword     asyStructure    struct typedef
-syn keyword     asyStorageClass static public readable private explicit
+syn keyword     asyStorageClass static public restricted private explicit
 
 syn keyword     asyPathSpec     and cycle controls tension atleast curl
 
-syn keyword     asyConstant     true false
-syn keyword     asyConstant     null nullframe nullpath
+syn keyword     asyConstant     true false default infinity inf
+syn keyword     asyConstant     null nullframe nullpath nullpen
 
 if exists("asy_syn_plain")
   syn keyword   asyConstant     currentpicture currentpen currentprojection
@@ -118,6 +118,7 @@ if exists("asy_syn_plain")
   syn keyword   asyConstant     E NE N NW W SW S SE
   syn keyword   asyConstant     ENE NNE NNW WNW WSW SSW SSE ESE
   syn keyword   asyConstant     I pi twopi
+  syn keyword   asyConstant     identity zeroTransform
   syn keyword   asyConstant     solid dotted dashed dashdotted
   syn keyword   asyConstant     longdashed longdashdotted
   syn keyword   asyConstant     squarecap roundcap extendcap

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -27,15 +27,11 @@ syn keyword     asyTodo         contained TODO FIXME XXX
 syn cluster     asyCommentGroup contains=asyTodo
 
 " String and Character constants
-" Highlight special characters (those proceding a double backslash) differently
-syn match       asySpecial      display contained "\\\\."
-" Highlight line continuation slashes
-syn match       asySpecial      display contained "\\$"
-syn region      asyString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=asySpecial
-  " asyCppString: same as asyString, but ends at end of line
-if 0
-syn region      asyCppString    start=+"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=asySpecial
-endif
+syn region      asyString        start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=asySpecial
+syn match       asySpecial       display contained +\\\(['"?\\abfnrtv]\|\o\{1,3}\|x[0-9A-F]\{1,2\}\|$\)+
+" double quoted strings only special character is \"
+syn region      asyDoubleString  start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=asyDoubleSpecial
+syn match       asyDoubleSpecial display contained +[^\\]\(\\\\\)*\zs\\"+
 
 "when wanted, highlight trailing white space
 if exists("asy_space_errors")
@@ -48,24 +44,24 @@ if exists("asy_space_errors")
 endif
 
 "catch errors caused by wrong parenthesis and brackets
-syn cluster     asyParenGroup   contains=asyParenError,asyIncluded,asySpecial,asyCommentSkip,asyCommentString,asyComment2String,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
+syn cluster     asyParenGroup   contains=asyParenError,asyIncluded,asySpecial,asyDoubleSpecial,asyCommentSkip,asyCommentString,asyComment2String,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
 if exists("asy_no_bracket_error")
   syn region    asyParen        transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyCppString
   " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppParen     transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString
+  syn region    asyCppParen     transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString,asyDoubleString
   syn match     asyParenError   display ")"
   syn match     asyErrInParen   display contained "[{}]"
 else
   syn region    asyParen        transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyErrInBracket,asyCppBracket,asyCppString
   " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppParen     transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString
+  syn region    asyCppParen     transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString,asyDoubleString
 if 0
   syn match     asyParenError   display "[\])]"
   syn match     asyErrInParen   display contained "[\]]"
 endif
   syn region    asyBracket      transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen,asyCppParen,asyCppBracket,asyCppString
   " asyCppBracket: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppBracket   transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString
+  syn region    asyCppBracket   transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString,asyDoubleString
   syn match     asyErrInBracket display contained "[);]"
 endif
 
@@ -82,14 +78,14 @@ syn match       asyFloat        display contained "\d\+e[-+]\=\d\+"
 syn case match
 
 if exists("asy_comment_strings")
-  " A comment can contain asyString, asyCharacter and asyNumber.
-  " But a "*/" inside a asyString in a asyComment DOES end the comment!  So we
-  " need to use a special type of asyString: asyCommentString, which also ends on
+  " A comment can contain asyString, asyDoubleString, asyCharacter and asyNumber.
+  " But a "*/" inside a asy*String in a asyComment DOES end the comment!  So we
+  " need to use a special type of asy*String: asyCommentString, which also ends on
   " "*/", and sees a "*" at the start of the line as comment again.
   " Unfortunately this doesn't very well work for // type of comments :-(
   syn match     asyCommentSkip       contained "^\s*\*\($\|\s\+\)"
-  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCommentSkip
-  syn region    asyComment2String    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial
+  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyDoubleSpecial,asyCommentSkip
+  syn region    asyComment2String    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial,asyDoubleSpecial
   syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyComment2String,asyCharacter,asyNumbersCom,asySpaceError
   syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyCharacter,asyNumbersCom,asySpaceError
 else
@@ -186,8 +182,10 @@ if version >= 508 || !exists("did_asy_syn_inits")
   HiLink asyComment2String      asyString
   HiLink asyCommentSkip         asyComment
   HiLink asyString              String
+  HiLink asyDoubleString        String
   HiLink asyComment             Comment
   HiLink asySpecial             SpecialChar
+  HiLink asyDoubleSpecial       SpecialChar
   HiLink asyTodo                Todo
   HiLink asyCppSkip             asyCppOut
   HiLink asyCppOut2             asyCppOut

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -165,10 +165,12 @@ if exists("asy_comment_strings")
   " "*/", and sees a "*" at the start of the line as comment again.
   " Unfortunately this doesn't very well work for // type of comments :-(
   syn match     asyCommentSkip       contained "^\s*\*\($\|\s\+\)"
-  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asyCSpecial,asyCommentSkip
-  syn region    asyCommentLString    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asyCSpecial
-  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyCommentLString,asyNumbers
-  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyNumbers
+  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCommentSkip
+  syn region    asyCommentCString    contained start=+L\='+ skip=+\\\\\|\\'+ end=+'+ end=+\*/+me=s-1 contains=asyCSpecial,asyCommentSkip
+  syn region    asyCommentLString    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial
+  syn region    asyCommentLCString   contained start=+L\='+ skip=+\\\\\|\\'+ end=+'+ end="$" contains=asyCSpecial
+  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyCommentLString,asyCommentLCString,asyNumbers
+  syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyCommentCString,asyNumbers
 else
   syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup
   syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError
@@ -232,7 +234,9 @@ if version >= 508 || !exists("did_asy_syn_inits")
   HiLink asyType                 Type
   HiLink asyConstant             Constant
   HiLink asyCommentString        asyString
+  HiLink asyCommentCString       asyString
   HiLink asyCommentLString       asyString
+  HiLink asyCommentLCString      asyString
   HiLink asyCommentSkip          asyComment
   HiLink asyString               String
   HiLink asyCString              String

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -33,16 +33,6 @@ syn match       asySpecial       display contained +\\\(['"?\\abfnrtv]\|\o\{1,3}
 syn region      asyDoubleString  start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=asyDoubleSpecial
 syn match       asyDoubleSpecial display contained +[^\\]\(\\\\\)*\zs\\"+
 
-"when wanted, highlight trailing white space
-if exists("asy_space_errors")
-  if !exists("asy_no_trail_space_error")
-    syn match   asySpaceError    display excludenl "\s\+$"
-  endif
-  if !exists("asy_no_tab_space_error")
-    syn match   asySpaceError    display " \+\t"me=e-1
-  endif
-endif
-
 "catch errors caused by wrong parenthesis and brackets
 syn cluster     asyParenGroup    contains=asyParenError,asyIncluded,asySpecial,asyDoubleSpecial,asyCommentSkip,asyCommentString,asyComment2String,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
 if exists("asy_no_bracket_error")

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -27,31 +27,31 @@ syn keyword     asyTodo          contained TODO FIXME XXX
 syn cluster     asyCommentGroup  contains=asyTodo
 
 " String and Character constants
-syn region      asyString        start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=asySpecial
-syn match       asySpecial       display contained +\\\(['"?\\abfnrtv]\|\o\{1,3}\|x[0-9A-F]\{1,2\}\|$\)+
+syn region      asyCString       start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=asyCSpecial
+syn match       asyCSpecial      display contained +\\\(['"?\\abfnrtv]\|\o\{1,3}\|x[0-9A-F]\{1,2\}\|$\)+
 " double quoted strings only special character is \"
-syn region      asyDoubleString  start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=asyDoubleSpecial
-syn match       asyDoubleSpecial display contained +[^\\]\(\\\\\)*\zs\\"+
+syn region      asyString        start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=asySpecial
+syn match       asySpecial       display contained +[^\\]\(\\\\\)*\zs\\"+
 
 "catch errors caused by wrong parenthesis and brackets
-syn cluster     asyParenGroup    contains=asyParenError,asyIncluded,asySpecial,asyDoubleSpecial,asyCommentSkip,asyCommentString,asyComment2String,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
+syn cluster     asyParenGroup    contains=asyParenError,asyIncluded,asySpecial,asyCSpecial,asyCommentSkip,asyCommentString,asyCommentLString,@asyCommentGroup,asyCommentStartError,asyUserCont,asyUserLabel,asyBitField,asyCommentSkip,asyOctalZero,asyCppOut,asyCppOut2,asyCppSkip,asyFormat,asyNumber,asyFloat,asyOctal,asyOctalError,asyNumbersCom
 if exists("asy_no_bracket_error")
   syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyCppString
   " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString,asyDoubleString
+  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyParen,asyString,asyCString
   syn match     asyParenError    display ")"
   syn match     asyErrInParen    display contained "[{}]"
 else
   syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyCppParen,asyErrInBracket,asyCppBracket,asyCppString
   " asyCppParen: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString,asyDoubleString
+  syn region    asyCppParen      transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInBracket,asyParen,asyBracket,asyString,asyCString
 if 0
   syn match     asyParenError    display "[\])]"
   syn match     asyErrInParen    display contained "[\]]"
 endif
   syn region    asyBracket       transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen,asyCppParen,asyCppBracket,asyCppString
   " asyCppBracket: same as asyParen but ends at end-of-line; used in asyDefine
-  syn region    asyCppBracket    transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString,asyDoubleString
+  syn region    asyCppBracket    transparent start='\[' skip='\\$' excludenl end=']' end='$' contained contains=ALLBUT,@asyParenGroup,asyErrInParen,asyParen,asyBracket,asyString,asyCString
   syn match     asyErrInBracket  display contained "[);]"
 endif
 
@@ -68,15 +68,15 @@ syn match       asyFloat         display contained "\d\+e[-+]\=\d\+"
 syn case match
 
 if exists("asy_comment_strings")
-  " A comment can contain asyString, asyDoubleString, asyCharacter and asyNumber.
+  " A comment can contain asyString, asyCString, asyCharacter and asyNumber.
   " But a "*/" inside a asy*String in a asyComment DOES end the comment!  So we
   " need to use a special type of asy*String: asyCommentString, which also ends on
   " "*/", and sees a "*" at the start of the line as comment again.
   " Unfortunately this doesn't very well work for // type of comments :-(
   syn match     asyCommentSkip       contained "^\s*\*\($\|\s\+\)"
-  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyDoubleSpecial,asyCommentSkip
-  syn region    asyComment2String    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial,asyDoubleSpecial
-  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyComment2String,asyCharacter,asyNumbersCom,asySpaceError
+  syn region    asyCommentString     contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end=+\*/+me=s-1 contains=asySpecial,asyCSpecial,asyCommentSkip
+  syn region    asyCommentLString    contained start=+L\="+ skip=+\\\\\|\\"+ end=+"+ end="$" contains=asySpecial,asyCSpecial
+  syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asyCommentLString,asyCharacter,asyNumbersCom,asySpaceError
   syn region    asyComment           matchgroup=asyCommentStart start="/\*" matchgroup=NONE end="\*/" contains=@asyCommentGroup,asyCommentStartError,asyCommentString,asyCharacter,asyNumbersCom,asySpaceError
 else
   syn region    asyCommentL          start="//" skip="\\$" end="$" keepend contains=@asyCommentGroup,asySpaceError
@@ -252,13 +252,13 @@ if version >= 508 || !exists("did_asy_syn_inits")
   HiLink asyType                 Type
   HiLink asyConstant             Constant
   HiLink asyCommentString        asyString
-  HiLink asyComment2String       asyString
+  HiLink asyCommentLString       asyString
   HiLink asyCommentSkip          asyComment
   HiLink asyString               String
-  HiLink asyDoubleString         String
+  HiLink asyCString              String
   HiLink asyComment              Comment
   HiLink asySpecial              SpecialChar
-  HiLink asyDoubleSpecial        SpecialChar
+  HiLink asyCSpecial             SpecialChar
   HiLink asyTodo                 Todo
   HiLink asyCppSkip              asyCppOut
   HiLink asyCppOut2              asyCppOut

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -178,20 +178,14 @@ syn keyword     asyTodo              contained TODO FIXME XXX
 syn sync ccomment asyComment minlines=15
 
 " delimiter matching errors
-syn cluster     asyParenGroup    contains=asyParenError,asyCSpecial,asyCommentSkip,asyCommentString,asyCommentLString,@asyCommentGroup,asyCommentStartError,asyNumbers
-if exists("asy_no_bracket_error")
-  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup
-  syn match     asyParenError    display ")"
-  syn match     asyErrInParen    display contained "[{}]"
-else
-  syn region    asyParen         transparent start='(' end=')' contains=ALLBUT,@asyParenGroup,asyErrInBracket
-if 0
-  syn match     asyParenError    display "[\])]"
-  syn match     asyErrInParen    display contained "[\]]"
-endif
-  syn region    asyBracket       transparent start='\[' end=']' contains=ALLBUT,@asyParenGroup,asyErrInParen
-  syn match     asyErrInBracket  display contained "[);]"
-endif
+syn region asyCurly      transparent start='{'  end='}'  contains=TOP,asyCurlyError
+syn region asyBrack      transparent start='\[' end='\]' matchgroup=asyError end=';' contains=TOP,asyBrackError
+syn region asyParen      transparent start='('  end=')'  matchgroup=asyError end=';' contains=TOP,asyParenError
+syn match  asyCurlyError display '}'
+syn match  asyBrackError display '\]'
+syn match  asyParenError display ')'
+" for (;;) constructs are exceptions that allow ; inside parenthesis
+syn region asyParen      transparent matchgroup=asyParen start='\(for\s*\)\@<=(' end=')' contains=TOP,asyParenError
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already
@@ -209,9 +203,9 @@ if version >= 508 || !exists("did_asy_syn_inits")
   HiLink asyRepeat               Repeat
   HiLink asyNumber               Number
   HiLink asyNumberError          asyError
+  HiLink asyCurlyError           asyError
+  HiLink asyBracketError         asyError
   HiLink asyParenError           asyError
-  HiLink asyErrInParen           asyError
-  HiLink asyErrInBracket         asyError
   HiLink asyCommentError         asyError
   HiLink asyCommentStartError    asyError
   HiLink asyOperator             Operator

--- a/base/asy.vim
+++ b/base/asy.vim
@@ -86,7 +86,7 @@ endif
 syn match       asyCommentError      display "\*/"
 syn match       asyCommentStartError display "/\*"me=e-1 contained
 
-syn keyword     asyType          void bool int real string file
+syn keyword     asyType          void bool bool3 int real string file
 syn keyword     asyType          pair triple transform guide path pen frame
 syn keyword     asyType          picture
 
@@ -95,31 +95,114 @@ syn keyword     asyStorageClass  static public restricted private explicit
 
 syn keyword     asyPathSpec      and cycle controls tension atleast curl
 
-syn keyword     asyConstant      true false default infinity inf
+syn keyword     asyConstant      VERSION
+syn keyword     asyConstant      true false default infinity inf nan
 syn keyword     asyConstant      null nullframe nullpath nullpen
+syn keyword     asyConstant      intMin intMax realMin realMax
+syn keyword     asyConstant      realEpsilon realDigits
 
 if exists("asy_syn_plain")
-  syn keyword   asyConstant      currentpicture currentpen currentprojection
+  syn keyword   asyConstant      currentpicture currentpen defaultpen
   syn keyword   asyConstant      inch inches cm mm bp pt up down right left
   syn keyword   asyConstant      E NE N NW W SW S SE
   syn keyword   asyConstant      ENE NNE NNW WNW WSW SSW SSE ESE
   syn keyword   asyConstant      I pi twopi
-  syn keyword   asyConstant      identity zeroTransform
+  syn keyword   asyConstant      CCW CW
+  syn keyword   asyConstant      undefined sqrtEpsilon Align mantissaBits
+  syn keyword   asyConstant      identity zeroTransform invert
+  syn keyword   asyConstant      stdin stdout
+  syn keyword   asyConstant      unitsquare unitcircle circleprecision
   syn keyword   asyConstant      solid dotted Dotted dashed dashdotted
   syn keyword   asyConstant      longdashed longdashdotted
   syn keyword   asyConstant      squarecap roundcap extendcap
   syn keyword   asyConstant      miterjoin roundjoin beveljoin
-  syn keyword   asyConstant      zerowinding evenodd
-  syn keyword   asyConstant      invisible black gray grey white
-  syn keyword   asyConstant      lightgray lightgrey
-  syn keyword   asyConstant      red green blue
-  syn keyword   asyConstant      cmyk Cyan Magenta Yellow Black
-  syn keyword   asyConstant      yellow magenta cyan
-  syn keyword   asyConstant      brown darkgreen darkblue
-  syn keyword   asyConstant      orange purple royalblue olive
-  syn keyword   asyConstant      chartreuse fuchsia salmon lightblue
-  syn keyword   asyConstant      springgreen pink
+  syn keyword   asyConstant      zerowinding evenodd basealign nobasealign
+  syn keyword   asyConstant      black white gray red green blue Cyan Magenta
+  syn keyword   asyConstant      Yellow Black cyan magenta yellow palered
+  syn keyword   asyConstant      palegreen paleblue palecyan palemagenta
+  syn keyword   asyConstant      paleyellow palegray lightred lightgreen
+  syn keyword   asyConstant      lightblue lightcyan lightmagenta lightyellow
+  syn keyword   asyConstant      lightgray mediumred mediumgreen mediumblue
+  syn keyword   asyConstant      mediumcyan mediummagenta mediumyellow
+  syn keyword   asyConstant      mediumgray heavyred heavygreen heavyblue
+  syn keyword   asyConstant      heavycyan heavymagenta lightolive heavygray
+  syn keyword   asyConstant      deepred deepgreen deepblue deepcyan
+  syn keyword   asyConstant      deepmagenta deepyellow deepgray darkred
+  syn keyword   asyConstant      darkgreen darkblue darkcyan darkmagenta
+  syn keyword   asyConstant      darkolive darkgray orange fuchsia chartreuse
+  syn keyword   asyConstant      springgreen purple royalblue salmon brown
+  syn keyword   asyConstant      olive darkbrown pink palegrey lightgrey
+  syn keyword   asyConstant      mediumgrey grey heavygrey deepgrey darkgrey
+
+  if exists("asy_texcolors")
+    syn keyword asyConstant      GreenYellow Yellow Goldenrod Dandelion
+    syn keyword asyConstant      Apricot Peach Melon YellowOrange Orange
+    syn keyword asyConstant      BurntOrange Bittersweet RedOrange Mahogany
+    syn keyword asyConstant      Maroon BrickRed Red OrangeRed RubineRed
+    syn keyword asyConstant      WildStrawberry Salmon CarnationPink Magenta
+    syn keyword asyConstant      VioletRed Rhodamine Mulberry RedViolet
+    syn keyword asyConstant      Fuchsia Lavender Thistle Orchid DarkOrchid
+    syn keyword asyConstant      Purple Plum Violet RoyalPurple BlueViolet
+    syn keyword asyConstant      Periwinkle CadetBlue CornflowerBlue
+    syn keyword asyConstant      MidnightBlue NavyBlue RoyalBlue Blue
+    syn keyword asyConstant      Cerulean Cyan ProcessBlue SkyBlue Turquoise
+    syn keyword asyConstant      TealBlue Aquamarine BlueGreen Emerald
+    syn keyword asyConstant      JungleGreen SeaGreen Green ForestGreen
+    syn keyword asyConstant      PineGreen LimeGreen YellowGreen SpringGreen
+    syn keyword asyConstant      OliveGreen RawSienna Sepia Brown Tan Gray
+    syn keyword asyConstant      Black White
+  endif
+
+  if exists("asy_x11colors")
+    syn keyword asyConstant      AliceBlue AntiqueWhite Aqua Aquamarine Azure
+    syn keyword asyConstant      Beige Bisque Black BlanchedAlmond Blue
+    syn keyword asyConstant      BlueViolet Brown BurlyWood CadetBlue
+    syn keyword asyConstant      Chartreuse Chocolate Coral CornflowerBlue
+    syn keyword asyConstant      Cornsilk Crimson Cyan DarkBlue DarkCyan
+    syn keyword asyConstant      DarkGoldenrod DarkGray DarkGreen DarkKhaki
+    syn keyword asyConstant      DarkMagenta DarkOliveGreen DarkOrange
+    syn keyword asyConstant      DarkOrchid DarkRed DarkSalmon DarkSeaGreen
+    syn keyword asyConstant      DarkSlateBlue DarkSlateGray DarkTurquoise
+    syn keyword asyConstant      DarkViolet DeepPink DeepSkyBlue DimGray
+    syn keyword asyConstant      DodgerBlue FireBrick FloralWhite ForestGreen
+    syn keyword asyConstant      Fuchsia Gainsboro GhostWhite Gold Goldenrod
+    syn keyword asyConstant      Gray Green GreenYellow Honeydew HotPink
+    syn keyword asyConstant      IndianRed Indigo Ivory Khaki Lavender
+    syn keyword asyConstant      LavenderBlush LawnGreen LemonChiffon
+    syn keyword asyConstant      LightBlue LightCoral LightCyan
+    syn keyword asyConstant      LightGoldenrodYellow LightGreen LightGrey
+    syn keyword asyConstant      LightPink LightSalmon LightSeaGreen
+    syn keyword asyConstant      LightSkyBlue LightSlateGray LightSteelBlue
+    syn keyword asyConstant      LightYellow Lime LimeGreen Linen Magenta
+    syn keyword asyConstant      Maroon MediumAquamarine MediumBlue
+    syn keyword asyConstant      MediumOrchid MediumPurple MediumSeaGreen
+    syn keyword asyConstant      MediumSlateBlue MediumSpringGreen
+    syn keyword asyConstant      MediumTurquoise MediumVioletRed MidnightBlue
+    syn keyword asyConstant      MintCream MistyRose Moccasin NavajoWhite
+    syn keyword asyConstant      Navy OldLace Olive OliveDrab Orange
+    syn keyword asyConstant      OrangeRed Orchid PaleGoldenrod PaleGreen
+    syn keyword asyConstant      PaleTurquoise PaleVioletRed PapayaWhip
+    syn keyword asyConstant      PeachPuff Peru Pink Plum PowderBlue Purple
+    syn keyword asyConstant      Red RosyBrown RoyalBlue SaddleBrown Salmon
+    syn keyword asyConstant      SandyBrown SeaGreen Seashell Sienna Silver
+    syn keyword asyConstant      SkyBlue SlateBlue SlateGray Snow SpringGreen
+    syn keyword asyConstant      SteelBlue Tan Teal Thistle Tomato Turquoise
+    syn keyword asyConstant      Violet Wheat White WhiteSmoke Yellow
+    syn keyword asyConstant      YellowGreen
+  endif
+
+  if exists("asy_syn_three")
+    syn keyword asyType          path3 guide3 transform3
+    syn keyword asyType          projection light material patch surface tube
+    syn keyword asyConstant      currentprojection currentlight defaultrender
+    syn keyword asyConstant      identity4 O X Y Z
+    syn keyword asyConstant      nolight nullpens
+    syn keyword asyConstant      unitsphere unithemisphere unitplane octant1
+    syn keyword asyConstant      unitcone unitsolidcone unitcube unitcylinder
+    syn keyword asyConstant      unitdisk unittube
+  endif
 endif
+
 
 syn sync ccomment asyComment minlines=15
 


### PR DESCRIPTION
I want to suggest some changes to the VIM syntax file. Let me try to summarize everything that's changed:

 - **Keywords**: many keywords were missing and I added a lot of them. There are new options to enable color related keywords and `three`-module related ones.
 - **String constants**: previously, only double quoted strings were highlighted and escaped characters were wrong. Now both single and double quoted strings are properly highlighted and special characters for each also work.
 - **Number constants**: fixed some errors such as: only lowercase `e` is recognized now (`1.0e10`), dangerous implicit scaling such as (`0.1.1` = `0.1 * .1`) are highlighted as errors.
 - **Comment strings**: also allows for both flavors of strings (single and double quoted)
 - **Delimiter matching**: unmatched delimiter highlighting has been reviewed, unmatched parenthesis and square brackets causes the next semicolon to be highlighted, which is closer to the source of the problem.
 - **Removed feature**: doesn't highlight trailing white spaces as this can be achieved by other plugins.
 - **Potentially controversial change**: the last commit limits the column width of the source file, which I don't think it's widely adopted for VimL sources.
 
The keywords might be worth discussing further, even though I added a lot of them, there are still much more such as all the ones listed in `asy-keywords.el`. Maybe we could categorize them and add all of them in the syntax file? Or maybe that would be overkill? Many keywords are both functions and variables for instance and without LSP, just populating a syntax file might just lead to some oddities.