### PR TITLE
Fixed runtime error when drawing degenerate path with TexHead arrow.

### DIFF
--- a/base/plain_arrows.asy
+++ b/base/plain_arrows.asy
@@ -157,7 +157,7 @@ TeXHead.head=new path(path g, position position=EndPoint, pen p=currentpen,
                                                            if(relative) position=reltime(g,position);
                                                            path r=subpath(g,position,0);
                                                            pair y=point(r,arctime(r,size));
-                                                           return shift(y)*rotate(degrees(-dir(r,arctime(r,0.5*size))))*gp;
+                                                           return shift(y)*rotate(degrees(-dir(r,arctime(r,0.5*size)),false))*gp;
 };
 TeXHead.defaultfilltype=new filltype(pen p) {return Fill(p);};
 


### PR DESCRIPTION
Currently running `draw((0, 0) -- (0, 0), arrow=Arrow(TeXHead))`
triggers a runtime error, whereas `draw((0, 0) -- (0, 0), arrow=Arrow)`
succeeds. This is due to a `degrees()` call that doesn't suppress
warnings. Here, the warnings are suppressed so that the TeXHead
version works.

Note that the appearance of the TeXHead arrow on a degenerate path
with this change is different from the other arrowheads: the former shows
up as normal, pointing right, whereas the latter all show up as a dot. This
is due to the static sizing of the TeXHead arrowhead.