### PR TITLE
DRAFT: Add dockerized version of asymptote

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,176 @@
+# mostly from .gitignore, but also additional files
+# (such as .git)
+# IDE Files
+.vs
+.vscode
+.idea
+
+# git
+.git
+
+# cuda reflection
+cudareflect
+!cudareflect/tinyexr
+
+dockerfile
+.editorconfig
+.clang-format
+.gdbinit
+.gitignore
+
+*.v3d
+
+LspCpp/CMakeCache.txt
+LspCpp/CMakeFiles
+
+### Generated files
+newDrawing.asy
+Makefile
+doc/Makefile
+doc/png/Makefile
+doc/FAQ/asy-faq.*
+!doc/FAQ/asy-faq.bfnn
+*.png
+*.gif
+*.pnm
+*.jpg
+*.prc
+*.svg
+*.roff
+doc/png/*.html
+GUI/*.pyc
+GUI/*/*.pyc
+GUI/*/__pycache__
+.wisdom
+allsymbols.h
+asy-keywords.el
+asy.list
+autom4te.cache/
+builtin.symbols.h
+camp.output
+camp.tab.cc
+camp.tab.h
+config.h
+config.h.in
+config.status
+configure
+doc/asy-latex.i*
+doc/asy.1
+glrender.d.54461
+gsl.symbols.h
+keywords.cc
+lex.yy.cc
+opsymbols.h
+types.symbols.h
+*.dSYM
+.DS_Store
+
+history
+
+### Compressed packages and Garbage Collector
+gc-*
+*.tar.gz
+*.tgz
+
+### Binaries
+asy
+xasy
+
+### Version info
+*version.*
+revision.*
+GUI/xasyVersion.py
+
+### Runtime objects
+run*.cc
+run*.h
+
+### TeX-related
+## Core latex/pdflatex auxiliary files:
+*_.tex
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.tuc
+
+## Intermediate documents:
+*.dvi
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+*.ps
+*.eps
+*.pdf
+*.pre
+*.m9
+#*-[0-9].*
+/doc/**/asymptote.*
+!/doc/asymptote.texi
+/doc/options
+.asy_*
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.brf
+*.run.xml
+
+### Debugging files
+core.*
+
+### Backups
+*~
+\#*
+.\#*
+
+### Generated python UI files
+GUI/pyUIClass/*
+GUI/__pycache__/*
+GUI/.env
+
+examples/_ig_*.asy
+
+### Shorthand Dev Script
+asydev
+gdb_xasy
+
+_ig_*/*
+
+### Translation binary files
+*.mo
+
+### SVG Icons
+GUI/res/*
+!GUI/res/icons.qrc
+!GUI/res/*.svg
+
+### RC Icons
+GUI/icons_rc.py
+
+
+# apitrace outputs
+*.trace
+
+## TODO: Use git lfs to store a larger HDRi format (but bandwidth)?
+## Or tell people to store it elsewhere?
+base/res/*.hdr
+base/res/*.exr
+*.bak
+*.tar.gz.*
+
+renderDocSettings
+
+*.html
+!index.html
+!webgl/WebGL*.html
+
+v3dheadertypes.h
+v3dtypes.h
+base/v3dheadertypes.asy
+base/v3dtypes.asy

--- a/Makefile.in
+++ b/Makefile.in
@@ -22,6 +22,8 @@ BISON ?= bison
 PYRCC ?= pyrcc5
 PYUIC ?= pyuic5
 
+MAKECPUCOUNT ?= 1
+
 # Libraries needed to make asymptote.so.
 # We have to remove OpenGL, threading, GC, etc from this.
 SHAREDLIBS = $(filter-out -lglut -GL -pthread $(GCLIBS), $(LIBS))
@@ -164,6 +166,10 @@ liblspcpp.a:
 	cd LspCpp && $(CMAKE) -DCMAKE_CXX_FLAGS="-fPIE @OPTIONS@ -I../$(GC)/include" CMakeLists.txt && $(MAKE)
 
 all:  	asy sty man faq asy-keywords.el
+
+dockerized-asy:
+	docker system prune
+	docker build ${CURDIR} -t asy -f dockerfile/asy.dockerfile --build-arg MAKE_CPU_COUNT=$(MAKECPUCOUNT) -t asy
 
 $(GCLIB): $(GC).tar.gz
 	gunzip -c $(GC).tar.gz > $(GC).tar

--- a/dockerfile/asy.dockerfile
+++ b/dockerfile/asy.dockerfile
@@ -1,0 +1,45 @@
+FROM alpine:3.16.2
+
+ARG ASY_VERSION=git-master
+
+LABEL org.opencontainers.image.authors="Andy Hammerlindl, John C. Bowman, Tom Prince"
+LABEL org.opencontainers.image.url=asymptote.sourceforge.io
+LABEL ca.ualberta.asymptote.maintainer="Supakorn 'Jamie' Rassameemasmuang <jamievlin@outlook.com>"
+
+RUN apk update && apk upgrade
+
+# pip is to install pyuic5-tool.
+# We don't need the entire qt package, which can take up to ~400MB
+RUN apk add autoconf make gcc g++ zlib-dev gc-dev \
+    cmake python3 py3-pip bison flex gsl-dev readline-dev
+
+RUN pip3 install pyuic5-tool
+RUN mkdir /asy
+
+COPY . /asy
+WORKDIR /asy
+
+RUN autoheader && autoconf
+
+# LSP can be definitely enabled, and even possibly used as a backend
+# for static analysis support in many editors (such as vscode)
+
+# We have to disable OpenGL for now
+# fftw can be enabled at a later date
+RUN ./configure --prefix=/opt --disable-lsp --disable-gl --disable-fftw
+
+ARG MAKE_CPU_COUNT=1
+
+# Remove any dangling files
+RUN make clean
+RUN make asy -j$MAKE_CPU_COUNT
+
+ENV ASYMPTOTE_DIR=/asy/base
+
+# for png & support for other formats
+RUN apk add ghostscript
+RUN mkdir /workdir
+
+WORKDIR /workdir
+ENTRYPOINT ["/asy/asy"]
+CMD ["--help"]


### PR DESCRIPTION
Hi John,

** Please do not merge in yet, this is a /very/ crude merge request and there are alot of improvements that can be made **

This is a simple merge request to add a dockerized build script for asymptote. One advantage of dockerized containers is that users can launch asymptote directly with minimal configuration, anywhere (for example, if someone is not familiar with asy's dependencies).

To build, run `make MAKECPUCOUNT=<cpu count> dockerized-asy`, and to run dockerized asy, map the current directory to /workdir then run the image, for example,

`docker run --rm --volume ~/documents:/workdir asy diagram.asy -fpdf`.

This image shows a crude working asymptote docker image.

![image](https://user-images.githubusercontent.com/11280210/186353940-153bd8fa-227a-4b8a-b8ab-3eb8fc3c3c07.png)

-- Jamie