### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/generate_enums.py
+++ b/generate_enums.py
@@ -14,7 +14,9 @@ from typing import List, Tuple, Any, Union
 from datetime import datetime
 import io
 import argparse
+import os
 import sys
+import time
 import re
 
 def cleanComment(s):
@@ -47,12 +49,18 @@ def create_enums(filename: str) -> List[Union[Tuple[str, int, str], Tuple[str, i
     return final_list
 
 
+def datetime_now():
+    return datetime.utcfromtimestamp(
+        int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+    )
+
+
 def generate_enum_cpp(outname, enums, name, comment=None, *args, **kwargs):
     with io.open(outname, 'w') as fil:
         fil.write('// Enum class for {0}\n'.format(name))
         if comment is not None:
             fil.write('// {0}\n'.format(comment))
-        fil.write('// Generated at {0}\n\n'.format(datetime.now()))
+        fil.write('// Generated at {0}\n\n'.format(datetime_now()))
         if 'namespace' in kwargs:
             fil.write('namespace {0}\n'.format(kwargs['namespace']))
             fil.write('{\n')
@@ -79,7 +87,7 @@ def generate_enum_java(outname, enums, name, comment=None, *args, **kwargs):
         fil.write('// Enum class for {0}\n'.format(name))
         if comment is not None:
             fil.write('// {0}\n'.format(comment))
-        fil.write('// Generated at {0}\n\n'.format(datetime.now()))
+        fil.write('// Generated at {0}\n\n'.format(datetime_now()))
 
         if 'package' in kwargs:
             fil.write('package {0};\n'.format(kwargs['package']))
@@ -122,7 +130,7 @@ def generate_enum_asy(outname, enums, name, comment=None, *args, **kwargs):
         fil.write('// Enum class for {0}\n'.format(name))
         if comment is not None:
             fil.write('// {0}\n'.format(comment))
-        fil.write('// Generated at {0}\n\n'.format(datetime.now()))
+        fil.write('// Generated at {0}\n\n'.format(datetime_now()))
 
         fil.write('struct {0}\n'.format(name))
         fil.write('{\n')
@@ -145,7 +153,7 @@ def generate_enum_py(outname, enums, name, comment=None, *args, **kwargs):
         fil.write('# Enum class for {0}\n'.format(name))
         if comment is not None:
             fil.write('""" {0} """\n'.format(comment))
-        fil.write('# Generated at {0}\n\n'.format(datetime.now()))
+        fil.write('# Generated at {0}\n\n'.format(datetime_now()))
         fil.write('class {0}:\n'.format(name))
         for enumTxt, enumNum, *ar in enums:
             fil.write('    {0}_{2}={1}\n'.format(name, enumNum, enumTxt))


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).