### PR TITLE
io: Fix reading of NaN and inf values

### DIFF
--- a/fileio.cc
+++ b/fileio.cc
@@ -75,6 +75,42 @@ void ifile::ignoreComment()
   }
 }
 
+void ifile::Read(double& val) {
+  char c;
+  std::string str;
+  bool neg;
+
+  while(isspace(c = stream->peek())) stream->ignore();
+  neg = stream->peek() == '-';
+  // Try parsing the input as a number.
+  if(*stream >> val)
+    return;
+
+  clear();
+
+  switch(stream->peek()) {
+    case 'I': case 'i': // inf
+    case 'N': case 'n': // NaN
+      for(Int i=0; i < 3 && stream->good(); i++) str += stream->get();
+      break;
+    default:
+      stream->setstate(std::ios_base::failbit);
+      return;
+  }
+
+  if (!strcasecmp(str.c_str(), "inf"))
+    val = std::numeric_limits<double>::infinity();
+  else if (!strcasecmp(str.c_str(), "nan"))
+    val = std::numeric_limits<double>::quiet_NaN();
+  else {
+    for(auto it=str.rbegin(); it!=str.rend(); ++it) stream->putback(*it);
+    stream->setstate(std::ios_base::failbit);
+    return;
+  }
+
+  if (neg) val = -val;
+}
+
 bool ifile::eol()
 {
   int c;

--- a/fileio.h
+++ b/fileio.h
@@ -416,7 +416,7 @@ public:
 
   void Read(bool &val) {string t; readwhite(t); val=(t == "true");}
   void Read(Int& val) {*stream >> val;}
-  void Read(double& val) {*stream >> val;}
+  void Read(double& val);
   void Read(pair& val) {*stream >> val;}
   void Read(triple& val) {*stream >> val;}
   void Read(char& val) {stream->get(val);}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 .NOTPARALLEL:
 
-TESTDIRS = string arith frames types imp array pic gs
+TESTDIRS = string arith frames types imp array pic gs io
 
 EXTRADIRS = gsl output
 

--- a/tests/io/csv.asy
+++ b/tests/io/csv.asy
@@ -1,0 +1,18 @@
+import TestLib;
+
+StartTest("csv");
+{
+    real[] a=input("io/input_with_nan.csv").csv();
+    assert(a.length == 20);
+    for (int i=0; i<4; ++i)
+	assert(a[i] == i);
+    for (int i=4; i<8; ++i)
+	assert(isnan(a[i]));
+    for (int i=8; i<12; ++i)
+	assert(isnan(a[i]));
+    for (int i=12; i<16; ++i)
+	assert(a[i] == inf);
+    for (int i=16; i<20; ++i)
+	assert(a[i] == -inf);
+}
+EndTest();

--- a/tests/io/input_with_nan.csv
+++ b/tests/io/input_with_nan.csv
@@ -1,0 +1,5 @@
+   0,   1,   2,   3
+ NaN, NAN, nan, nAn
+-NaN,-NAN,-nan,-nAn
+ InF, INF, inf, iNf
+-InF,-INF,-inf,-iNf


### PR DESCRIPTION
Previously asymptote would silently stop while trying to read a textual dataset containing inf or nan values, while the language itself is perfectly capable of handling such values.

I've moved the implementation to the `fileio.c` file because modifying the header file caused an endless amount of unneeded recompilations.