### PR TITLE
Change VERSION to ASYVERSION

### DIFF
--- a/psfile.cc
+++ b/psfile.cc
@@ -152,7 +152,7 @@ void psfile::prologue(const bbox& box)
 {
   header(true);
   BoundingBox(box);
-  *out << "%%Creator: " << settings::PROGRAM << " " << settings::VERSION
+  *out << "%%Creator: " << settings::PROGRAM << " " << settings::ASYVERSION
        << REVISION <<  newl;
 
   time_t t; time(&t);

--- a/settings.cc
+++ b/settings.cc
@@ -212,7 +212,7 @@ void queryRegistry()
 #endif
 
 const char PROGRAM[]=PACKAGE_NAME;
-const char VERSION[]=PACKAGE_VERSION;
+const char ASYVERSION[]=PACKAGE_VERSION;
 const char BUGREPORT[]=PACKAGE_BUGREPORT;
 
 // The name of the program (as called).  Used when displaying help info.

--- a/settings.h
+++ b/settings.h
@@ -40,7 +40,7 @@ void endwait(pthread_cond_t& signal, pthread_mutex_t& lock);
 
 namespace settings {
 extern const char PROGRAM[];
-extern const char VERSION[];
+extern const char ASYVERSION[];
 extern const char BUGREPORT[];
 
 extern char *argv0;


### PR DESCRIPTION
This fixes compilation on my local Ubuntu 22 machines. Otherwise, I get the following error:
```
settings.h:43:19: error: expected unqualified-id before string constant
   43 | extern const char VERSION[];
```
The name change seems to resolve this issue.  The error shows up in the current head of master (03587f0f), as well as the 2.91 and 2.92 source-code releases.