### PR TITLE
Initialize positions to nullPos.

### DIFF
--- a/asyprocess.cc
+++ b/asyprocess.cc
@@ -101,6 +101,7 @@ public:
   penv() : _ge(0), _pd() {
     // Push the processData first, as it needs to be on the stack before genv
     // is initialized.
+    _pd.topPos = nullPos;
     processDataStack.push(&_pd);
     _ge = new genv;
   }

--- a/builtin.cc
+++ b/builtin.cc
@@ -81,7 +81,7 @@ void gen_rungsl_venv(venv &ve);
 
 void addType(tenv &te, symbol name, ty *t)
 {
-  te.enter(name, new tyEntry(t,0,0,position()));
+  te.enter(name, new tyEntry(t,0,0,nullPos));
 }
 
 // The base environments for built-in types and functions
@@ -140,7 +140,7 @@ void addFunc(venv &ve, access *a, ty *result, symbol id,
 
   // NOTE: If the function is a field, we should encode the defining record in
   // the entry
-  varEntry *ent = new varEntry(fun, a, 0, position());
+  varEntry *ent = new varEntry(fun, a, 0, nullPos);
 
   ve.enter(id, ent);
 }
@@ -182,7 +182,7 @@ void addOpenFunc(venv &ve, bltin f, ty *result, symbol name)
   REGISTER_BLTIN(f, name);
   access *a= new bltinAccess(f);
 
-  varEntry *ent = new varEntry(fun, a, 0, position());
+  varEntry *ent = new varEntry(fun, a, 0, nullPos);
 
   ve.enter(name, ent);
 }
@@ -210,7 +210,7 @@ void addRestFunc(venv &ve, bltin f, ty *result, symbol name, formal frest,
 
   if (frest.t) fun->addRest(frest);
 
-  varEntry *ent = new varEntry(fun, a, 0, position());
+  varEntry *ent = new varEntry(fun, a, 0, nullPos);
 
   ve.enter(name, ent);
 }
@@ -301,7 +301,7 @@ template<class T>
 void addVariable(venv &ve, T *ref, ty *t, symbol name,
                  record *module=settings::getSettingsModule()) {
   access *a = new refAccess<T>(ref);
-  varEntry *ent = new varEntry(t, a, PUBLIC, module, 0, position());
+  varEntry *ent = new varEntry(t, a, PUBLIC, module, 0, nullPos);
   ve.enter(name, ent);
 }
 
@@ -312,7 +312,7 @@ void addVariable(venv &ve, T value, ty *t, symbol name,
   item* ref=new item;
   *ref=value;
   access *a = new itemRefAccess(ref);
-  varEntry *ent = new varEntry(t, a, perm, module, 0, position());
+  varEntry *ent = new varEntry(t, a, perm, module, 0, nullPos);
   ve.enter(name, ent);
 }
 

--- a/constructor.cc
+++ b/constructor.cc
@@ -61,7 +61,7 @@ void transConstructorBody(position pos, coenv &e, record *r, varEntry *init)
   varEntry *v=makeVarEntry(pos, e, 0 /* not a field */, r);
 
   // Initialize the object.  a=new Foo;
-  newRecordExp::transFromTyEntry(pos, e, new tyEntry(r, 0, 0, position()));
+  newRecordExp::transFromTyEntry(pos, e, new tyEntry(r, 0, 0, nullPos));
   v->encode(WRITE, pos, e.c);
   e.c.encodePop();
 

--- a/dec.cc
+++ b/dec.cc
@@ -128,7 +128,7 @@ arrayTy::operator string() const
 }
 
 tyEntryTy::tyEntryTy(position pos, types::ty *t)
-  : astType(pos), ent(new trans::tyEntry(t, 0, 0, position()))
+  : astType(pos), ent(new trans::tyEntry(t, 0, 0, nullPos))
 {
 }
 
@@ -622,7 +622,7 @@ void addVar(coenv &e, record *r, varEntry *v, symbol id)
 {
   // Test for 'operator init' definitions that implicitly define constructors:
   if (definesImplicitConstructor(e, r, v, id))
-    addConstructorFromInitializer(position(), e, r, v);
+    addConstructorFromInitializer(nullPos, e, r, v);
 
   // Add to the record so it can be accessed when qualified; add to the
   // environment so it can be accessed unqualified in the scope of the
@@ -1479,7 +1479,7 @@ void recorddec::createSymMap(AsymptoteLsp::SymbolContext* symContext)
 runnable *autoplainRunnable() {
   // Abstract syntax for the code:
   //   private import plain;
-  position pos=position();
+  position pos=nullPos;
   static importdec ap(pos, new idpair(pos, symbol::literalTrans("plain")));
   static modifiedRunnable mr(pos, trans::PRIVATE, &ap);
 

--- a/exp.cc
+++ b/exp.cc
@@ -143,9 +143,9 @@ types::ty *tempExp::trans(coenv &e) {
 
 
 varEntryExp::varEntryExp(position pos, types::ty *t, access *a)
-  : exp(pos), v(new trans::varEntry(t, a, 0, position())) {}
+  : exp(pos), v(new trans::varEntry(t, a, 0, nullPos)) {}
 varEntryExp::varEntryExp(position pos, types::ty *t, vm::bltin f)
-  : exp(pos), v(new trans::varEntry(t, new bltinAccess(f), 0, position())) {}
+  : exp(pos), v(new trans::varEntry(t, new bltinAccess(f), 0, nullPos)) {}
 
 void varEntryExp::prettyprint(ostream &out, Int indent) {
   prettyname(out, "varEntryExp", indent, getPos());

--- a/name.cc
+++ b/name.cc
@@ -131,7 +131,7 @@ tyEntry *simpleName::tyEntryTrans(coenv &e)
   if (!ent) {
     em.error(getPos());
     em << "no type of name \'" << id << "\'";
-    return new tyEntry(primError(), 0, 0, position());
+    return new tyEntry(primError(), 0, 0, nullPos);
   }
   return ent;
 }
@@ -298,14 +298,14 @@ tyEntry *qualifiedName::tyEntryTrans(coenv &e)
 
   record *r = castToRecord(rt, false);
   if (!r)
-    return new tyEntry(primError(), 0, 0, position());
+    return new tyEntry(primError(), 0, 0, nullPos);
 
   tyEntry *ent = r->e.lookupTyEntry(id);
   if (!ent) {
     em.error(getPos());
     em << "no matching type of name \'" << id << "\' in \'"
        << *r << "\'";
-    return new tyEntry(primError(), 0, 0, position());
+    return new tyEntry(primError(), 0, 0, nullPos);
   }
   ent->reportPerm(READ, getPos(), e.c);
 

--- a/profiler.h
+++ b/profiler.h
@@ -25,13 +25,13 @@ string lookupBltin(bltin b);
 
 inline position positionFromLambda(lambda *func) {
   if (func == 0)
-    return position();
+    return nullPos;
 
   program& code = *func->code;
 
   // Check for empty program.
   if (code.begin() == code.end())
-    return position();
+    return nullPos;
 
   return code.begin()->pos;
 }

--- a/record.cc
+++ b/record.cc
@@ -68,7 +68,7 @@ dummyRecord::dummyRecord(string s)
 void dummyRecord::add(string name, ty *t, trans::access *a,
                       trans::permission perm) {
   e.addVar(symbol::trans(name),
-           new trans::varEntry(t, a, perm, this, this, position()));
+           new trans::varEntry(t, a, perm, this, this, nullPos));
 }
 
 void dummyRecord::add(string name, function *t, vm::bltin f,

--- a/types.cc
+++ b/types.cc
@@ -76,14 +76,14 @@ void ty::print(ostream& out) const
 #define FIELD(Type, name, func)                                 \
   if (sig == 0 && id == name) {                                 \
     static trans::virtualFieldAccess a(run::func);              \
-    static trans::varEntry v(Type(), &a, 0, position());        \
+    static trans::varEntry v(Type(), &a, 0, nullPos);        \
     return &v;                                                  \
   }
 
 #define RWFIELD(Type, name, getter, setter)                             \
   if (sig == 0 && id == name) {                                         \
     static trans::virtualFieldAccess a(run::getter, run::setter);       \
-    static trans::varEntry v(Type(), &a, 0, position());                \
+    static trans::varEntry v(Type(), &a, 0, nullPos);                \
     return &v;                                                          \
   }
 
@@ -92,7 +92,7 @@ void ty::print(ostream& out) const
       equivalent(sig, Type()->getSignature()))                          \
     {                                                                   \
       static trans::virtualFieldAccess a(run::func, 0, run::func##Helper); \
-      static trans::varEntry v(Type(), &a, 0, position());              \
+      static trans::varEntry v(Type(), &a, 0, nullPos);              \
       return &v;                                                        \
     }
 
@@ -104,7 +104,7 @@ void ty::print(ostream& out) const
       /* for some fields, v needs to be dynamic */                      \
       /* e.g. when the function type depends on an array type. */       \
       trans::varEntry *v =                                              \
-        new trans::varEntry(name##Type(), &a, 0, position());           \
+        new trans::varEntry(name##Type(), &a, 0, nullPos);           \
       return v;                                                         \
     }
 


### PR DESCRIPTION
The `position` constructor cannot initialize any of its fields (not even to null or zero) since yacc/bison puts it into a union. In this PR, many calls to this constructor (which does nothing) are replaced by making a copy of `nullPos` to ensure that the fields are actually initialized and behavior is more deterministic. I have also initialized a `position` field in `asyprocess.cc` to `nullPos` that I discovered was occasionally being used before it was initialized.

Bizarrely, this change appears to make a test script run roughly 8% faster. It's hard to say for sure; I'm comparing the mean of two sets of 10 runs, and each set had a fairly small standard deviation, but it's still possible that my processor was a bit hotter (for unrelated reasons) during one run than the other. Here's the test script I was using (which takes roughly 3 seconds to run on my machine):

```asy
int fib(int i) {
  return i < 2 ? i : fib(i - 1) + fib(i - 2);
}

write(fib(33));
```

I have run this code through `make check`, although I have not tried it with multiple configurations.