### PR TITLE
Fix build issues for January 2025

### DIFF
--- a/.github/actions/initialize-linux-latex-and-gs/action.yml
+++ b/.github/actions/initialize-linux-latex-and-gs/action.yml
@@ -1,0 +1,14 @@
+name: initialize-env
+description: Initialize environment
+runs:
+  using: 'composite'
+  steps:
+    - name: Update apt
+      shell: bash
+      run: sudo apt-get update
+    - name: Install latex
+      shell: bash
+      run: sudo apt-get install texlive texlive-latex-extra texinfo
+    - name: Install ghostscript
+      shell: bash
+      run: sudo apt-get install ghostscript

--- a/.github/workflows/build-asy-linux.yml
+++ b/.github/workflows/build-asy-linux.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 1
       - uses: ./.github/actions/initialize-linux-env
       - run: |
-          ASY_VERSION_OVERRIDE="${{ inputs.version_override }}" cmake --preset linux/release-ccache
+          ASY_VERSION_OVERRIDE="${{ inputs.version_override }}" cmake --preset linux/release/ci/with-ccache
       - name: tar+gz cmake configuration
         run: tar -czf cmake-linux-cfg-artifact.tar.gz --exclude='vcpkg_installed' cmake-build-linux/release
       - name: Upload configuration artifacts
@@ -51,7 +51,7 @@ jobs:
           echo set\(ASY_VERSION_SUFFIX \"/github-ci/ref=${{ github.sha }}\"\) > asy-pkg-version-suffix.cmake
       - run: cmake --build --preset linux/release --target asy-with-basefiles -j
       - name: build misc files
-        run: cmake --build --preset linux/release-ccache --target asy-dist-misc-files -j
+        run: cmake --build --preset linux/release/ci/with-ccache --target asy-dist-misc-files -j
       - name: Archive build files
         uses: actions/upload-artifact@v4
         with:
@@ -97,11 +97,11 @@ jobs:
       - name: delete cache file
         run: rm -f cmake-build-linux/release/CMakeCache.txt
       - name: reconfigure with documentation
-        run: ASY_VERSION_OVERRIDE="${{ inputs.version_override }}" cmake --preset linux/release-ccache
+        run: ASY_VERSION_OVERRIDE="${{ inputs.version_override }}" cmake --preset linux/release/ci/with-ccache
       - name: touch asymptote binary (to avoid need for rebuilding)
         run: touch cmake-build-linux/release/asy
       - name: build documentation
-        run: cmake --build --preset linux/release-ccache --target docgen -j
+        run: cmake --build --preset linux/release/ci/with-ccache --target docgen -j
       - name: Archive asymptote.pdf
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-asy-linux.yml
+++ b/.github/workflows/build-asy-linux.yml
@@ -87,8 +87,7 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/initialize-linux-env
-      - name: install dependencies
-        run: sudo apt-get install texlive texlive-latex-extra texinfo ghostscript
+      - uses: ./.github/actions/initialize-linux-latex-and-gs
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build-asy-windows.yml
+++ b/.github/workflows/build-asy-windows.yml
@@ -18,7 +18,7 @@ env:
         -Arch amd64 -HostArch amd64 -SkipAutomaticLocation
       $env:VCPKG_ROOT = "$env:VCPKG_INSTALLATION_ROOT"
       $env:ASY_VERSION_OVERRIDE = "${{ inputs.version_override }}"
-  cmake_msvc_profile: msvc/release-with-existing-asymptote-pdf
+  cmake_msvc_profile: msvc/release/ci/with-external-asymptote-pdf
 jobs:
   configure-windows-msvc-x64:
     runs-on: "windows-2022"

--- a/.github/workflows/linux-sanity.yml
+++ b/.github/workflows/linux-sanity.yml
@@ -15,15 +15,12 @@ jobs:
         run: |
           cmake --preset linux/release/ci/with-ccache/compact-zero
           cmake --build --preset linux/release/ci/with-ccache/compact-zero --target asy-with-basefiles -j
+      - uses: ./.github/actions/initialize-linux-latex-and-gs
       - name: Run asy base tests
         run: |
           ctest --test-dir cmake-build-linux/release-compact-zero \
             -R "^asy\..*" \
-            -E "asy\.(gc\..*|pic\.trans|gs\.ghostscript)"
+            -E "asy\.(gc\..*)"
       - name: Run asy wce test
         run: |
           ctest --test-dir cmake-build-linux/release-compact-zero -R "^wce"
-      - uses: ./.github/actions/initialize-linux-latex-and-gs
-      - name: Run asy latex tests
-        run: |
-          ctest --test-dir cmake-build-linux/release-compact-zero -R "^asy\.(gs\.ghostscript|pic\.trans)\..*"

--- a/.github/workflows/linux-sanity.yml
+++ b/.github/workflows/linux-sanity.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Run asy wce test
         run: |
           ctest --test-dir cmake-build-linux/release-compact-zero -R "^wce"
-      - name: Install LaTeX and ghostscript
-        run: sudo apt-get install texlive texlive-latex-extra texinfo ghostscript
+      - uses: ./.github/actions/initialize-linux-latex-and-gs
       - name: Run asy latex tests
         run: |
           ctest --test-dir cmake-build-linux/release-compact-zero -R "^asy\.(gs\.ghostscript|pic\.trans)\..*"

--- a/.github/workflows/linux-sanity.yml
+++ b/.github/workflows/linux-sanity.yml
@@ -1,0 +1,30 @@
+name: build-gui
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-and-test-asy-compact-zero:
+    runs-on: "ubuntu-22.04"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/initialize-linux-env
+      - name: Configure and build asymptote with compact 0
+        run: |
+          cmake --preset linux/release/ci/with-ccache/compact-zero
+          cmake --build --preset linux/release/ci/with-ccache/compact-zero --target asy-with-basefiles -j
+      - name: Run asy base tests
+        run: |
+          ctest --test-dir cmake-build-linux/release-compact-zero \
+            -R "^asy\..*" \
+            -E "asy\.(gc\..*|pic\.trans|gs\.ghostscript)"
+      - name: Run asy wce test
+        run: |
+          ctest --test-dir cmake-build-linux/release-compact-zero -R "^wce"
+      - name: Install LaTeX and ghostscript
+        run: sudo apt-get install texlive texlive-latex-extra texinfo ghostscript
+      - name: Run asy latex tests
+        run: |
+          ctest --test-dir cmake-build-linux/release-compact-zero -R "^asy\.(gs\.ghostscript|pic\.trans)\..*"

--- a/.github/workflows/pull-req-precheck.yml
+++ b/.github/workflows/pull-req-precheck.yml
@@ -26,6 +26,8 @@ jobs:
           asyver="$(python3 generate_asy_ver_info.py --version-with-git-info)ci"
           echo "Asymptote version is $asyver"
           echo "asyver=$asyver" >> "$GITHUB_OUTPUT"
+  linux-sanity:
+    uses: ./.github/workflows/linux-sanity.yml
   build-asy-linux:
     needs: determine_asy_version
     uses: ./.github/workflows/build-asy-linux.yml
@@ -55,6 +57,7 @@ jobs:
     uses: ./.github/workflows/package-asy-installer-win.yml
   precheck-pass:  # this is a dummy step with the sole purpose of making the PR need only this job to pass
     needs:
+      - linux-sanity
       - test-asy-linux
       - test-asy-windows
       - package-asy-install-file

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,6 @@
     },
     {
       "name": "linux/release/ci/with-ccache",
-      "displayName": "[linux-x86/64] Release (with ccache)",
       "binaryDir": "${sourceDir}/cmake-build-linux/release",
       "inherits": [
         "linux/release",
@@ -31,7 +30,6 @@
     },
     {
       "name": "linux/release/ci/with-ccache/compact-zero",
-      "displayName": "[linux-x86/64] Release (with ccache + COMPACT=0 mode)",
       "binaryDir": "${sourceDir}/cmake-build-linux/release-compact-zero",
       "inherits": [
         "linux/release/ci/with-ccache",
@@ -56,7 +54,6 @@
     },
     {
       "name": "msvc/release/ci/with-external-asymptote-pdf",
-      "displayName": "[MSVC-x86/64] Release (with external asymptote.pdf)",
       "inherits": [
         "msvc/release"
       ],
@@ -67,7 +64,6 @@
     },
     {
       "name": "msvc/release/with-external-doc-files",
-      "displayName": "[MSVC-x86/64] Release (with external documentation)",
       "inherits": [
         "msvc/release/ci/with-external-asymptote-pdf"
       ],
@@ -77,7 +73,6 @@
     },
     {
       "name": "msvc/release/with-external-doc-files/with-ctan",
-      "displayName": "[MSVC-x86/64] Release (with external documentation) for CTAN",
       "inherits": [
         "msvc/release/with-external-doc-files",
         "base/ctan"
@@ -103,7 +98,6 @@
     },
     {
       "name": "linux/release/ci/with-ccache",
-      "displayName": "[linux-x86/64] Release (with ccache)",
       "configurePreset": "linux/release/ci/with-ccache",
       "inherits": [
         "build-base/linux-only"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,7 +21,7 @@
       ]
     },
     {
-      "name": "linux/release-ccache",
+      "name": "linux/release/ci/with-ccache",
       "displayName": "[linux-x86/64] Release (with ccache)",
       "binaryDir": "${sourceDir}/cmake-build-linux/release",
       "inherits": [
@@ -46,7 +46,7 @@
       }
     },
     {
-      "name": "msvc/release-with-existing-asymptote-pdf",
+      "name": "msvc/release/ci/with-external-asymptote-pdf",
       "displayName": "[MSVC-x86/64] Release (with external asymptote.pdf)",
       "inherits": [
         "msvc/release"
@@ -57,20 +57,20 @@
       }
     },
     {
-      "name": "msvc/release-with-external-doc-files",
+      "name": "msvc/release/with-external-doc-files",
       "displayName": "[MSVC-x86/64] Release (with external documentation)",
       "inherits": [
-        "msvc/release-with-existing-asymptote-pdf"
+        "msvc/release/ci/with-external-asymptote-pdf"
       ],
       "cacheVariables": {
         "ENABLE_DOCGEN": "false"
       }
     },
     {
-      "name": "msvc/release-with-external-doc-file-ctan",
+      "name": "msvc/release/with-external-doc-files/with-ctan",
       "displayName": "[MSVC-x86/64] Release (with external documentation) for CTAN",
       "inherits": [
-        "msvc/release-with-external-doc-files",
+        "msvc/release/with-external-doc-files",
         "base/ctan"
       ]
     }
@@ -93,9 +93,9 @@
       ]
     },
     {
-      "name": "linux/release-ccache",
+      "name": "linux/release/ci/with-ccache",
       "displayName": "[linux-x86/64] Release (with ccache)",
-      "configurePreset": "linux/release-ccache",
+      "configurePreset": "linux/release/ci/with-ccache",
       "inherits": [
         "build-base/linux-only"
       ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 26,
+    "minor": 27,
     "patch": 0
   },
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,6 +14,7 @@
       "displayName": "[linux-x86/64] Release",
       "binaryDir": "${sourceDir}/cmake-build-linux/release",
       "inherits": [
+        "base/linux-only",
         "base/buildBaseWithVcpkg",
         "base/release",
         "base/allow_version_override_from_env"
@@ -86,12 +87,18 @@
     {
       "name": "linux/release",
       "displayName": "[linux-x86/64] Release",
-      "configurePreset": "linux/release"
+      "configurePreset": "linux/release",
+      "inherits": [
+        "build-base/linux-only"
+      ]
     },
     {
       "name": "linux/release-ccache",
       "displayName": "[linux-x86/64] Release (with ccache)",
-      "configurePreset": "linux/release-ccache"
+      "configurePreset": "linux/release-ccache",
+      "inherits": [
+        "build-base/linux-only"
+      ]
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,15 +29,6 @@
       ]
     },
     {
-      "name": "linux/releaseWithDebugInfo",
-      "displayName": "[linux-x86/64] Release with Debug Info",
-      "binaryDir": "${sourceDir}/cmake-build-linux/release-with-dbginfo",
-      "inherits": [
-        "base/buildBaseWithVcpkg",
-        "base/relWithDebInfo"
-      ]
-    },
-    {
       "name": "msvc/release",
       "displayName": "[MSVC-x86/64] Release",
       "binaryDir": "${sourceDir}/cmake-build-msvc/release",
@@ -81,21 +72,6 @@
         "msvc/release-with-external-doc-files",
         "base/ctan"
       ]
-    },
-    {
-      "name": "msvc/releaseWithDebugInfo",
-      "displayName": "[MSVC-x86/64] Release with debug info",
-      "binaryDir": "${sourceDir}/cmake-build-msvc/release-with-dbginfo",
-      "inherits": [
-        "base/buildBaseWithVcpkg",
-        "base/relWithDebInfo",
-        "base/gccCompatCacheVar",
-        "base/windows-only",
-        "base/ensure-cl-compiler"
-      ],
-      "cacheVariables": {
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/cmake-install-w32-nsis-reldbg"
-      }
     }
   ],
   "buildPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,6 +30,15 @@
       ]
     },
     {
+      "name": "linux/release/ci/with-ccache/compact-zero",
+      "displayName": "[linux-x86/64] Release (with ccache + COMPACT=0 mode)",
+      "binaryDir": "${sourceDir}/cmake-build-linux/release-compact-zero",
+      "inherits": [
+        "linux/release/ci/with-ccache",
+        "base/compact-zero-mode"
+      ]
+    },
+    {
       "name": "msvc/release",
       "displayName": "[MSVC-x86/64] Release",
       "binaryDir": "${sourceDir}/cmake-build-msvc/release",
@@ -96,6 +105,13 @@
       "name": "linux/release/ci/with-ccache",
       "displayName": "[linux-x86/64] Release (with ccache)",
       "configurePreset": "linux/release/ci/with-ccache",
+      "inherits": [
+        "build-base/linux-only"
+      ]
+    },
+    {
+      "name": "linux/release/ci/with-ccache/compact-zero",
+      "configurePreset": "linux/release/ci/with-ccache/compact-zero",
       "inherits": [
         "build-base/linux-only"
       ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,119 +5,49 @@
     "minor": 27,
     "patch": 0
   },
-
+  "include": [
+    "cmake-preset-files/base-presets.json"
+  ],
   "configurePresets": [
-    {
-      "name": "base",
-      "generator": "Ninja",
-      "architecture": {
-        "strategy": "external",
-        "value": "x64"
-      },
-      "hidden": true
-    },
-    {
-      "name": "base/ensure-cl-compiler",
-      "cacheVariables": {
-        "CMAKE_C_COMPILER": "cl",
-        "CMAKE_CXX_COMPILER": "cl"
-      },
-      "hidden": true
-    },
-    {
-      "name": "base/vcpkg",
-      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-      "hidden": true
-    },
-    {
-      "name": "base/release",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      },
-      "hidden": true
-    },
-    {
-      "name": "base/debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      },
-      "hidden": true
-    },
-    {
-      "name": "base/relWithDebInfo",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      },
-      "hidden": true
-    },
-    {
-      "name": "base/linuxCcache",
-      "cacheVariables": {
-        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
-      },
-      "hidden": true
-    },
-    {
-      "name": "base/gccCompatCacheVar",
-      "cacheVariables": {
-        "GCCCOMPAT_CXX_COMPILER_FOR_MSVC": "$env{GCCCOMPAT_CXX_COMPILER_FOR_MSVC}"
-      },
-      "hidden": true
-    },
-    {
-      "name": "base/buildBaseWithVcpkg",
-      "inherits": ["base", "base/vcpkg"],
-      "hidden": true
-    },
-    {
-      "name": "base/windows-only",
-      "hidden": true,
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "name": "base/allow_version_override_from_env",
-      "hidden": true,
-      "cacheVariables": {
-        "ASY_VERSION_OVERRIDE": "$env{ASY_VERSION_OVERRIDE}"
-      }
-    },
-    {
-      "name": "base/ctan",
-      "hidden": true,
-      "cacheVariables": {
-        "CTAN_BUILD": "true"
-      }
-    },
     {
       "name": "linux/release",
       "displayName": "[linux-x86/64] Release",
       "binaryDir": "${sourceDir}/cmake-build-linux/release",
-      "inherits": ["base/buildBaseWithVcpkg", "base/release", "base/allow_version_override_from_env"]
+      "inherits": [
+        "base/buildBaseWithVcpkg",
+        "base/release",
+        "base/allow_version_override_from_env"
+      ]
     },
     {
       "name": "linux/release-ccache",
       "displayName": "[linux-x86/64] Release (with ccache)",
       "binaryDir": "${sourceDir}/cmake-build-linux/release",
-      "inherits": ["linux/release", "base/linuxCcache"]
+      "inherits": [
+        "linux/release",
+        "base/linuxCcache"
+      ]
     },
     {
       "name": "linux/releaseWithDebugInfo",
       "displayName": "[linux-x86/64] Release with Debug Info",
       "binaryDir": "${sourceDir}/cmake-build-linux/release-with-dbginfo",
-      "inherits": ["base/buildBaseWithVcpkg", "base/relWithDebInfo"]
+      "inherits": [
+        "base/buildBaseWithVcpkg",
+        "base/relWithDebInfo"
+      ]
     },
     {
       "name": "msvc/release",
       "displayName": "[MSVC-x86/64] Release",
       "binaryDir": "${sourceDir}/cmake-build-msvc/release",
       "inherits": [
-        "base/buildBaseWithVcpkg", "base/release", "base/gccCompatCacheVar",
-        "base/windows-only", "base/ensure-cl-compiler", "base/allow_version_override_from_env"
+        "base/buildBaseWithVcpkg",
+        "base/release",
+        "base/gccCompatCacheVar",
+        "base/windows-only",
+        "base/ensure-cl-compiler",
+        "base/allow_version_override_from_env"
       ],
       "cacheVariables": {
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/cmake-install-w32-nsis-release"
@@ -126,7 +56,9 @@
     {
       "name": "msvc/release-with-existing-asymptote-pdf",
       "displayName": "[MSVC-x86/64] Release (with external asymptote.pdf)",
-      "inherits": ["msvc/release"],
+      "inherits": [
+        "msvc/release"
+      ],
       "cacheVariables": {
         "ENABLE_ASYMPTOTE_PDF_DOCGEN": "false",
         "EXTERNAL_DOCUMENTATION_DIR": "${sourceDir}/asydoc"
@@ -135,7 +67,9 @@
     {
       "name": "msvc/release-with-external-doc-files",
       "displayName": "[MSVC-x86/64] Release (with external documentation)",
-      "inherits": ["msvc/release-with-existing-asymptote-pdf"],
+      "inherits": [
+        "msvc/release-with-existing-asymptote-pdf"
+      ],
       "cacheVariables": {
         "ENABLE_DOCGEN": "false"
       }
@@ -143,37 +77,34 @@
     {
       "name": "msvc/release-with-external-doc-file-ctan",
       "displayName": "[MSVC-x86/64] Release (with external documentation) for CTAN",
-      "inherits": ["msvc/release-with-external-doc-files", "base/ctan"]
+      "inherits": [
+        "msvc/release-with-external-doc-files",
+        "base/ctan"
+      ]
     },
     {
       "name": "msvc/releaseWithDebugInfo",
       "displayName": "[MSVC-x86/64] Release with debug info",
       "binaryDir": "${sourceDir}/cmake-build-msvc/release-with-dbginfo",
       "inherits": [
-        "base/buildBaseWithVcpkg", "base/relWithDebInfo", "base/gccCompatCacheVar",
-        "base/windows-only", "base/ensure-cl-compiler"
+        "base/buildBaseWithVcpkg",
+        "base/relWithDebInfo",
+        "base/gccCompatCacheVar",
+        "base/windows-only",
+        "base/ensure-cl-compiler"
       ],
       "cacheVariables": {
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/cmake-install-w32-nsis-reldbg"
       }
     }
   ],
-
   "buildPresets": [
-    {
-      "name": "build-base/windows-only",
-      "hidden": true,
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-
     {
       "name": "msvc/release",
       "displayName": "[MSVC-x86/64] Release",
-      "inherits": [ "build-base/windows-only" ],
+      "inherits": [
+        "build-base/windows-only"
+      ],
       "configurePreset": "msvc/release"
     },
     {

--- a/INSTALL-WIN.md
+++ b/INSTALL-WIN.md
@@ -123,7 +123,7 @@ There are multiple CMake presets available for building, depending on what you i
 - If you are building Asymptote for release with setup files, depending on how you would build `asymptote.pdf`,
   use either (see #documentation-generation section)
   - The `msvc/release` preset
-  - The `msvc/msvc/release-with-existing-asymptote-pdf`
+  - The `msvc/msvc/release/with-existing-asymptote-pdf`
 - If you are building only asymptote executable for release, or do not care about `asymptote.pdf`, use `msvc/release` preset
 - If you are building Asymptote for development or debug mode,
   you are required to either create your own debug preset or configure cache variables manually.
@@ -144,7 +144,7 @@ There are multiple key targets for building Asymptote.
   See #building-gui-files for instructions on how to build GUI files.
 
 The Asymptote binary is available
-at `cmake-build-msvc/release/asy.exe` if using `msvc/release` or `msvc/msvc/release-with-existing-asymptote-pdf`
+at `cmake-build-msvc/release/asy.exe` if using `msvc/release` or `msvc/msvc/release/ci/with-external-asymptote-pdf`
 targets.
 Instructions for generating a setup file are in the next section
 
@@ -208,10 +208,10 @@ are present in the system.
 
 Place `asymptote.pdf` in the directory `<asymptote-repo>/asydoc/`.
 That is, the file `<asymptote-repo>/asydoc/asymptote.pdf` is present.
-After that, configure cmake with the preset `msvc/release-with-existing-asymptote-pdf` - that is,
+After that, configure cmake with the preset `msvc/release/ci/with-external-asymptote-pdf` - that is,
 
 ```powershell
-cmake --preset msvc/release-with-existing-asymptote-pdf
+cmake --preset msvc/release/ci/with-external-asymptote-pdf
 ```
 
 #### If generating `asymptote.pdf` as part of build process

--- a/Makefile.in
+++ b/Makefile.in
@@ -363,7 +363,7 @@ uninstall-docdir:
 
 clean:  FORCE
 	-rm -f asy asymptote.so *.pic.o *.o *.d *.raw.i *mon.out $(CLEAN)
-	-rm LspCpp/liblspcpp.a
+	-rm -f LspCpp/liblspcpp.a LspCpp/Makefile LspCpp/CMakeFiles
 	-cd LspCpp && $(MAKE) distclean
 	-cd tinyexr && $(MAKE) clean
 	-cd GUI && $(PYTHON) buildtool.py clean
@@ -374,6 +374,7 @@ gc-clean: FORCE clean
 cleaner: FORCE clean
 	-$(MAKE) -C $(GC) distclean
 	-rm -f Makefile config.h config.log config.status errors.temp
+	-rm -f LspCpp/CMakeCache.txt
 	cd doc && $(MAKE) clean
 	cd tests && $(MAKE) distclean
 

--- a/build-scripts/build-asymptote.ps1
+++ b/build-scripts/build-asymptote.ps1
@@ -256,7 +256,7 @@ function buildAsy($preset, $cfgDir) {
     # install to pre-installation root
 }
 
-buildAsy msvc/release-with-external-doc-files cmake-build-msvc/release
+buildAsy msvc/release/with-external-doc-files cmake-build-msvc/release
 cmake --install $asymptoteRoot/cmake-build-msvc/release --component asy-pre-nsis
 
 # ------------------------------------------------------
@@ -293,7 +293,7 @@ else
 # ------------------------------------------------------
 # building for CTAN
 
-buildAsy msvc/release-with-external-doc-file-ctan cmake-build-msvc/release
+buildAsy msvc/release/with-external-doc-files/with-ctan cmake-build-msvc/release
 
 if ($env:ASYMPTOTE_BUILD_SHARED_DIRECTORY)
 {

--- a/cmake-preset-files/base-presets.json
+++ b/cmake-preset-files/base-presets.json
@@ -1,0 +1,123 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "base",
+      "generator": "Ninja",
+      "architecture": {
+        "strategy": "external",
+        "value": "x64"
+      },
+      "hidden": true
+    },
+    {
+      "name": "base/ensure-cl-compiler",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl",
+        "CMAKE_CXX_COMPILER": "cl"
+      },
+      "hidden": true
+    },
+    {
+      "name": "base/vcpkg",
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+      "hidden": true
+    },
+    {
+      "name": "base/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      },
+      "hidden": true
+    },
+    {
+      "name": "base/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "hidden": true
+    },
+    {
+      "name": "base/relWithDebInfo",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "hidden": true
+    },
+    {
+      "name": "base/linuxCcache",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+      },
+      "hidden": true
+    },
+    {
+      "name": "base/gccCompatCacheVar",
+      "cacheVariables": {
+        "GCCCOMPAT_CXX_COMPILER_FOR_MSVC": "$env{GCCCOMPAT_CXX_COMPILER_FOR_MSVC}"
+      },
+      "hidden": true
+    },
+    {
+      "name": "base/buildBaseWithVcpkg",
+      "inherits": [
+        "base",
+        "base/vcpkg"
+      ],
+      "hidden": true
+    },
+    {
+      "name": "base/windows-only",
+      "hidden": true,
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "base/linux-only",
+      "hidden": true,
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "base/allow_version_override_from_env",
+      "hidden": true,
+      "cacheVariables": {
+        "ASY_VERSION_OVERRIDE": "$env{ASY_VERSION_OVERRIDE}"
+      }
+    },
+    {
+      "name": "base/ctan",
+      "hidden": true,
+      "cacheVariables": {
+        "CTAN_BUILD": "true"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "build-base/windows-only",
+      "hidden": true,
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "build-base/linux-only",
+      "hidden": true,
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    }
+  ]
+}

--- a/cmake-preset-files/base-presets.json
+++ b/cmake-preset-files/base-presets.json
@@ -98,6 +98,13 @@
       "cacheVariables": {
         "CTAN_BUILD": "true"
       }
+    },
+    {
+      "name": "base/compact-zero-mode",
+      "hidden": true,
+      "cacheVariables": {
+        "ENABLE_COMPACT_ZERO_BUILD": "true"
+      }
     }
   ],
   "buildPresets": [

--- a/cmake-scripts/asy-macro.cmake
+++ b/cmake-scripts/asy-macro.cmake
@@ -43,3 +43,8 @@ endif()
 if (CTAN_BUILD)
     list(APPEND ASY_MACROS CTAN_BUILD)
 endif()
+
+if (ENABLE_COMPACT_ZERO_BUILD)
+    message(STATUS "Setting COMPACT=0. Ensure this is not a production build.")
+    list(APPEND ASY_MACROS COMPACT=0)
+endif()

--- a/cmake-scripts/options.cmake
+++ b/cmake-scripts/options.cmake
@@ -99,6 +99,13 @@ option(DEBUG_GC_ENABLE "Enable debug mode for gc" false)
 option(DEBUG_GC_BACKTRACE_ENABLE "Enable backtrace for gc" false)
 option(CTAN_BUILD "Build for CTAN." false)
 
+option(
+        ENABLE_COMPACT_ZERO_BUILD "\
+Set COMPACT flag to 0. \
+Unless if building for debugging/testing with an explicit need for additional type verification, \
+this option should be turned off."
+        false)
+
 # additional optimization options
 
 if (CMAKE_BUILD_TYPE IN_LIST cmake_release_build_types)

--- a/configure.ac
+++ b/configure.ac
@@ -347,6 +347,8 @@ if test "x$enable_lsp" != "xno" -a "x$enable_threads" != "xno"; then
       if test "x$with_vcpkg" = "xno"; then
           LSP_CMAKE_OPTIONS=$LSP_CMAKE_OPTIONS"-DLSPCPP_GC_DOWNLOADED_ROOT=$ROOT_DIR_RELATIVE_TO_SRC/\$(GC) "
       fi
+   else
+      LSP_CMAKE_OPTIONS=$LSP_CMAKE_OPTIONS"-DLSPCPP_SUPPORT_BOEHM_GC=OFF "
    fi
 
    AC_DEFUN([ENABLE_LSP_MACRO],

--- a/configure.ac
+++ b/configure.ac
@@ -342,7 +342,7 @@ if test "x$enable_lsp" != "xno" -a "x$enable_threads" != "xno"; then
    LSPLIBS=$LSPLIBS" -L$LSP_BUILD_ROOT -L$LSP_BUILD_ROOT/third_party/uri/src -llspcpp -lnetwork-uri -lboost_filesystem -lboost_thread"
    LSP_CMAKE_OPTIONS="-DLSPCPP_USE_CPP17=ON "
 
-   if test "x$ac_cv_use_gc" != "xno"; then
+   if test "x$enable_gc" != "xno"; then
       LSP_CMAKE_OPTIONS=$LSP_CMAKE_OPTIONS"-DLSPCPP_SUPPORT_BOEHM_GC=ON "
       if test "x$with_vcpkg" = "xno"; then
           LSP_CMAKE_OPTIONS=$LSP_CMAKE_OPTIONS"-DLSPCPP_GC_DOWNLOADED_ROOT=$ROOT_DIR_RELATIVE_TO_SRC/\$(GC) "


### PR DESCRIPTION
In particular, this enables building with LSP + without gc for testing.

- **AC: Change ac_cv_use_gc to enable_gc in lsp configuration.**
- **AC: Add in LSPCPP_SUPPORT_BOEHM_GC=OFF explicitly to LSP_CMAKE_OPTIONS if gc is off.**
- **MAKE: Remove additional files from Lsp build process during clean.**
