### PR TITLE
Use external asy-keywords.el in windows build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,7 +68,8 @@
         "msvc/release/ci/with-external-asymptote-pdf"
       ],
       "cacheVariables": {
-        "ENABLE_DOCGEN": "false"
+        "ENABLE_DOCGEN": "false",
+        "ENABLE_MISCFILES_GEN": "false"
       }
     },
     {

--- a/build-scripts/build-asymptote.ps1
+++ b/build-scripts/build-asymptote.ps1
@@ -45,6 +45,7 @@ $requiredDocumentationFiles=@(
     "CAD.pdf"
     "TeXShopAndAsymptote.pdf"
     "asyRefCard.pdf"
+    "asy-keywords.el"
 )
 
 $hasDocFiles=$true


### PR DESCRIPTION


- **CMAKE: Disable miscfiles generation in msvc/release/with-external-doc-files preset.**
- **BUILD: Add asy-keywords.el to the list of requried documentation files for windows build script.**
