### PR TITLE
Fix various typos

### DIFF
--- a/INSTALL-VCPKG.md
+++ b/INSTALL-VCPKG.md
@@ -106,7 +106,7 @@ suffix is "+debug" for debug builds, or an empty string for all other builds, in
 
 ## Testing
 
-Asymptote unit testing is integerated into CMake's `CTest` framework.
+Asymptote unit testing is integrated into CMake's `CTest` framework.
 All Asymptote `.asy` based tests are named `asy.<test dirname>.<test file name>`
 excluding `*.asy` extension.
 

--- a/asyprocess.cc
+++ b/asyprocess.cc
@@ -591,7 +591,7 @@ class iprompt : public icore {
 
 
   // The interactive prompt has special functions that cannot be implemented as
-  // normal functions.  These special funtions take a commandLine as an argument
+  // normal functions.  These special functions take a commandLine as an argument
   // and return true if they can handle the command.  If false is returned, the
   // line is treated as a normal line of code.
   // commands is a map of command names to methods which implement the commands.

--- a/build-scripts/asy-format.el
+++ b/build-scripts/asy-format.el
@@ -1,14 +1,14 @@
-(defun change (old-pat new-pat) "Replace all occurences of old-pat to new-pat in current buffer."
+(defun change (old-pat new-pat) "Replace all occurrences of old-pat to new-pat in current buffer."
 (interactive "r")
 (goto-char (point-min))
 (replace-string old-pat new-pat))
 
-(defun changereg (old-regexp new-regexp) "Replace all occurences of old-regexp to new-regexp in current buffer."
+(defun changereg (old-regexp new-regexp) "Replace all occurrences of old-regexp to new-regexp in current buffer."
 (interactive "r")
 (goto-char (point-min))
 (replace-regexp old-regexp new-regexp))
 
-(defun querychangereg (old-regexp new-regexp) "Replace all occurences of old-regexp to new-regexp in current buffer, with query."
+(defun querychangereg (old-regexp new-regexp) "Replace all occurrences of old-regexp to new-regexp in current buffer, with query."
 (interactive "r")
 (goto-char (point-min))
 (query-replace-regexp old-regexp new-regexp))

--- a/build-scripts/cc-format.el
+++ b/build-scripts/cc-format.el
@@ -1,14 +1,14 @@
-(defun change (old-pat new-pat) "Replace all occurences of old-pat to new-pat in current buffer."
+(defun change (old-pat new-pat) "Replace all occurrences of old-pat to new-pat in current buffer."
 (interactive "r")
 (goto-char (point-min))
 (replace-string old-pat new-pat))
 
-(defun changereg (old-regexp new-regexp) "Replace all occurences of old-regexp to new-regexp in current buffer."
+(defun changereg (old-regexp new-regexp) "Replace all occurrences of old-regexp to new-regexp in current buffer."
 (interactive "r")
 (goto-char (point-min))
 (replace-regexp old-regexp new-regexp))
 
-(defun querychangereg (old-regexp new-regexp) "Replace all occurences of old-regexp to new-regexp in current buffer, with query."
+(defun querychangereg (old-regexp new-regexp) "Replace all occurrences of old-regexp to new-regexp in current buffer, with query."
 (interactive "r")
 (goto-char (point-min))
 (query-replace-regexp old-regexp new-regexp))

--- a/constructor.cc
+++ b/constructor.cc
@@ -50,7 +50,7 @@ bool definesImplicitConstructor(coenv &e, record *r, varEntry *v, symbol id)
   return false;
 }
 
-// Given the coenv of the body of the constructor, encode the neccessary
+// Given the coenv of the body of the constructor, encode the necessary
 // instructions to make a new initialized object.
 void transConstructorBody(position pos, coenv &e, record *r, varEntry *init)
 {

--- a/doc/asyRefCard.tex
+++ b/doc/asyRefCard.tex
@@ -524,8 +524,8 @@ do \statement
 \section{string operations}
 \key{concatenate operator}{+}
 \key{string length}{length(string)}
-\key{position $\ge$ {\tt pos} of first occurence of {\tt t} in {\tt s}}{find({\tt s},{\tt t},pos=0)}
-\key{position $\le$ {\tt pos} of last occurence of {\tt t} in {\tt s}}{rfind({\tt s},{\tt t},pos=-1)}
+\key{position $\ge$ {\tt pos} of first occurrence of {\tt t} in {\tt s}}{find({\tt s},{\tt t},pos=0)}
+\key{position $\le$ {\tt pos} of last occurrence of {\tt t} in {\tt s}}{rfind({\tt s},{\tt t},pos=-1)}
 \key{string with {\tt t} inserted in {\tt s} at {\tt pos}}{insert({\tt s},{\tt pos},{\tt t})}
 \key{string {\tt s} with {\tt n} characters at {\tt pos} erased}{erase({\tt s},{\tt pos},{\tt n})}
 \key{substring of string {\tt s} of length {\tt n} at {\tt pos}}{substr({\tt s},{\tt pos},{\tt n})}

--- a/doc/external-proposal.html
+++ b/doc/external-proposal.html
@@ -362,7 +362,7 @@ void f(int asyname:cname)
         file is processed, this C++ code is copied verbatim into an actual C++
         function providing the implementation.  However, the actual body of the
         resultant C++ function may contain code other than the body provided by
-        the user.  This auxillary code could include instruction to retrieve the
+        the user.  This auxiliary code could include instruction to retrieve the
         arguments of the function from their representation in the Asymptote
         virtual machine and bind them to local variables with their C++ names.
         It could also include initialization and finalization code for the

--- a/env.cc
+++ b/env.cc
@@ -40,7 +40,7 @@ access *protoenv::baseLookupCast(ty *target, ty *source, symbol name) {
          source->kind != ty_overloaded);
 
   // If errors already exist, don't report more.  This may, however, cause
-  // problems with resoving the signature of an overloaded function.  The
+  // problems with resolving the signature of an overloaded function.  The
   // abstract syntax should check if any of the parameters had an error before
   // finding the signature.
   if (target->kind == ty_error || source->kind == ty_error)

--- a/errormsg.h
+++ b/errormsg.h
@@ -241,7 +241,7 @@ public:
     anyStatusErrors=true;
   }
 
-  // Returns true if no errors have occured that should be reported by the
+  // Returns true if no errors have occurred that should be reported by the
   // return value of the process.
   bool processStatus() const {
     return !anyStatusErrors;

--- a/exp.h
+++ b/exp.h
@@ -1123,7 +1123,7 @@ public:
   types::ty *getType(coenv &e) override;
 };
 
-// Postfix expresions are illegal. This is caught here as we can give a
+// Postfix expressions are illegal. This is caught here as we can give a
 // more meaningful error message to the user, rather than a "parse
 // error."
 class postfixExp : public exp {

--- a/genv.h
+++ b/genv.h
@@ -9,7 +9,7 @@
  *
  * genv sets up the basic type bindings and function bindings for
  * builtin functions, casts and operators, and imports plain (if set),
- * but all other initialization, is done by the local environmet defined
+ * but all other initialization, is done by the local environment defined
  * in env.h.
  *****/
 

--- a/gsl.cc
+++ b/gsl.cc
@@ -1407,7 +1407,7 @@ void gen_rungsl_venv(venv &ve)
   addGSLRealRealRealFunc<gsl_cdf_gamma_Qinv>
     (SYM(cdf_gamma_Qinv),SYM(Q),SYM(a),SYM(b));
 
-  // Sperical distributions
+  // Spherical distributions
   addFunc(GSLModule->e.ve,GSLrng_dir2d,primPair(),SYM(rng_dir2d),
           formal(primString(),SYM(method),true,false));
   addFunc(GSLModule->e.ve,GSLrng_dir3d,primTriple(),SYM(rng_dir3d));

--- a/inst.h
+++ b/inst.h
@@ -2,7 +2,7 @@
  * inst.h
  * Andy Hammerlindl 2002/06/27
  *
- * Descibes the items and instructions that are used by the virtual machine.
+ * Describes the items and instructions that are used by the virtual machine.
  *****/
 
 #ifndef INST_H

--- a/item.h
+++ b/item.h
@@ -2,7 +2,7 @@
  * item.h
  * Tom Prince and John Bowman 2005/04/12
  *
- * Descibes the items that are used by the virtual machine.
+ * Describes the items that are used by the virtual machine.
  *****/
 
 #ifndef ITEM_H

--- a/knot.cc
+++ b/knot.cc
@@ -49,7 +49,7 @@ ostream& info(ostream& o, string name, knotlist& l)
 
 #define INFO(x) info(cerr,#x,x)
 
-/***** Auxillary computation functions *****/
+/***** Auxiliary computation functions *****/
 
 // Computes the relative distance of a control point given the angles.
 // The name is somewhat misleading as the velocity (with respect to the
@@ -204,7 +204,7 @@ struct dzprop : public knotprop<pair> {
 };
 
 // Compute the distance between points, using the already computed dz.  This
-// doesn't use the infomation in the knots, but the knotprop class is useful as
+// doesn't use the information in the knots, but the knotprop class is useful as
 // it takes care of the iteration for us.
 struct dprop : public knotprop<double> {
   cvector<pair>& dz;
@@ -331,13 +331,13 @@ cvector<weqn> recalc(cvector<eqn>& e)
   we.push_back(lasteqn); // As a placeholder.
   for (Int j=1; j < n; j++) {
     // Subtract a factor of the last equation so that the first entry is
-    // zero, then procede to scale it.
+    // zero, then proceed to scale it.
     eqn& q=e[j];
     lasteqn=scale(weqn(0,q.piv-q.pre*lasteqn.post,q.post,
                        q.aug-q.pre*lasteqn.aug,-q.pre*lasteqn.w));
     we.push_back(lasteqn);
   }
-  // To keep all of the infomation enocoded in the linear equations, we need
+  // To keep all of the information enocoded in the linear equations, we need
   // to augment the computation to replace our trivial start weqn with a
   // real one.  To do this, we take one more step in the iteration and
   // compute the weqn for j=n, since n=0 (mod n).
@@ -421,7 +421,7 @@ struct ref : public knotprop<eqn> {
   }
   eqn mid(Int j) {
     // Subtract a factor of the last equation so that the first entry is
-    // zero, then procede to scale it.
+    // zero, then proceed to scale it.
     eqn& q=e[j];
     return scale(eqn(0,q.piv-q.pre*lasteqn.post,q.post,
                      q.aug-q.pre*lasteqn.aug));

--- a/material.h
+++ b/material.h
@@ -97,7 +97,7 @@ public:
 
 extern size_t Nmaterials; // Number of materials compiled in shader
 extern size_t nmaterials; // Current size of materials buffer
-extern size_t Maxmaterials; // Maxinum size of materials buffer
+extern size_t Maxmaterials; // Maximum size of materials buffer
 }
 
 #endif

--- a/misc/aspy.py
+++ b/misc/aspy.py
@@ -134,7 +134,7 @@ class AsyException(Exception):
         return self.msg
 
 def checkForErrors():
-    """Raises an exception if an error occured."""
+    """Raises an exception if an error occurred."""
     global policyError
     if policyError != []:
         s = policyError[0]

--- a/path.cc
+++ b/path.cc
@@ -691,7 +691,7 @@ double path::arctime(double goal) const
 
 // }}}
 
-// {{{ Direction Time Calulation
+// {{{ Direction Time Calculation
 // Algorithm Stolen from Knuth's MetaFont
 inline double cubicDir(const solvedKnot& left, const solvedKnot& right,
                        const pair& rot)

--- a/pkg.m4
+++ b/pkg.m4
@@ -86,7 +86,7 @@ dnl Check to see whether a particular set of modules exists. Similar to
 dnl PKG_CHECK_MODULES(), but does not set variables or print errors.
 dnl
 dnl Please remember that m4 expands AC_REQUIRE([PKG_PROG_PKG_CONFIG])
-dnl only at the first occurence in configure.ac, so if the first place
+dnl only at the first occurrence in configure.ac, so if the first place
 dnl it's called might be skipped (such as if it is within an "if", you
 dnl have to call PKG_CHECK_EXISTS manually
 AC_DEFUN([PKG_CHECK_EXISTS],

--- a/primitives.h
+++ b/primitives.h
@@ -2,7 +2,7 @@
  * primitives.h
  * Andy Hammerlindl 2007/04/27
  *
- * A list of the primative types in Asymptote, defined using the
+ * A list of the primitive types in Asymptote, defined using the
  * PRIMITIVE(name,Name,asyName) macro.  This macro should be defined in by the
  * code including this file for the context at hand.
  *

--- a/settings.cc
+++ b/settings.cc
@@ -441,7 +441,7 @@ struct option : public gc {
 
   // Outputs description of the command for the -help option.
   virtual void describe(char option) {
-    // Don't show the option if it has no desciption.
+    // Don't show the option if it has no description.
     if(!hide() && ((option == 'h') ^ env())) {
       const unsigned WIDTH=22;
       string start=describeStart();

--- a/symbol.cc
+++ b/symbol.cc
@@ -39,7 +39,7 @@ struct symbolRecord {
 
 // The table size must be a power of two so that (h % tableSize) can be
 // replaced by (h & tableMask).  1 << 15 was chosen based on the number of
-// unique symbols (roughly 4000) which occured in all of the base modules.
+// unique symbols (roughly 4000) which occurred in all of the base modules.
 const size_t SYMBOL_TABLE_BASE_CAPACITY = 1 << 15;
 symbolRecord baseSymbolTable[SYMBOL_TABLE_BASE_CAPACITY];
 

--- a/symbolmaps.h
+++ b/symbolmaps.h
@@ -434,7 +434,7 @@ namespace AsymptoteLsp
     // access -> (file, id)
     // unravel -> id
     // include -> file
-    // import = acccess + unravel
+    // import = access + unravel
 
     using extRefMap = std::unordered_map<std::string, SymbolContext*>;
     extRefMap extFileRefs;
@@ -500,7 +500,7 @@ namespace AsymptoteLsp
     // access -> (file, id)
     // unravel -> id
     // include -> file
-    // import = acccess + unravel
+    // import = access + unravel
 
     ExternalRefs extRefs;
 


### PR DESCRIPTION
Found via `codespell -q 3 -L alo,atleast,clen,siz,sord,te,uptodate`