### PR TITLE
Check expected runtime errors in collections library.

### DIFF
--- a/base/collections/hashset.asy
+++ b/base/collections/hashset.asy
@@ -68,6 +68,7 @@ struct HashSet_T {
     for (int i = start; i < end; ++i) {
       HashEntry entry = buckets[i];
       if (entry == null) {
+        assert(isNullT != null, 'Item is not present.');
         return super.nullT;
       }
       if (entry.hash == bucket) {

--- a/base/collections/queue.asy
+++ b/base/collections/queue.asy
@@ -24,9 +24,11 @@ Queue_T makeNaiveQueue(T[] initialData) {
     data.push(value);
   };
   queue.peek = new T() {
+    assert(data.length > 0, 'Queue is empty');
     return data[0];
   };
   queue.pop = new T() {
+    assert(data.length > 0, 'Queue is empty');
     ++version;
     T retv = data[0];
     data.delete(0);
@@ -120,12 +122,12 @@ struct ArrayQueue_T {
   }
 
   T peek() {
-    assert(size > 0);
+    assert(size > 0, 'Queue is empty');
     return data[start];
   }
 
   T pop() {
-    assert(size > 0);
+    assert(size > 0, 'Queue is empty');
     T retv = data[start];
     ++start;
     --size;
@@ -202,10 +204,12 @@ struct LinkedQueue_T {
   }
 
   T peek() {
+    assert(size > 0, 'Queue is empty');
     return head.value;
   }
 
   T pop() {
+    assert(size > 0, 'Queue is empty');
     ++version;
     T retv = head.value;
     head = head.next;

--- a/cmake-scripts/tests-asy.cmake
+++ b/cmake-scripts/tests-asy.cmake
@@ -25,7 +25,7 @@ add_test(
         NAME bundled.asy.collections_errors
         COMMAND ${PY3_INTERPRETER} ${ASY_ASYLANG_TEST_ROOT}/test_collections_errors.py
             --asy $<TARGET_FILE:asy>
-            --base-dir=${ASY_BUILD_BASE_DIR}
+            --asy-base-dir=${ASY_BUILD_BASE_DIR}
         WORKING_DIRECTORY ${ASY_ASYLANG_TEST_ROOT}
 )
 set_property(

--- a/cmake-scripts/tests-asy.cmake
+++ b/cmake-scripts/tests-asy.cmake
@@ -20,3 +20,13 @@ set_property(
         APPEND
         PROPERTY ADDITIONAL_CLEAN_FILES ${ASY_ASYLANG_TEST_SCRATCH_DIR}
 )
+
+add_test(
+        NAME bundled.asy.collections_errors
+        COMMAND ${PY3_INTERPRETER} ${ASY_ASYLANG_TEST_ROOT}/test_collections_errors.py
+        WORKING_DIRECTORY ${ASY_ASYLANG_TEST_ROOT}
+)
+set_property(
+        TEST bundled.asy.collections_errors
+        PROPERTY LABELS asy-check-tests
+)

--- a/cmake-scripts/tests-asy.cmake
+++ b/cmake-scripts/tests-asy.cmake
@@ -24,6 +24,8 @@ set_property(
 add_test(
         NAME bundled.asy.collections_errors
         COMMAND ${PY3_INTERPRETER} ${ASY_ASYLANG_TEST_ROOT}/test_collections_errors.py
+            --asy $<TARGET_FILE:asy>
+            --base-dir=${ASY_BUILD_BASE_DIR}
         WORKING_DIRECTORY ${ASY_ASYLANG_TEST_ROOT}
 )
 set_property(

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,11 +2,15 @@
 
 TESTDIRS = $(wildcard */)
 
-test: $(TESTDIRS)
+test: $(TESTDIRS) test_collections_errors
 
 $(TESTDIRS)::
 	@echo
 	../asy -dir ../base $@*.asy
+
+test_collections_errors:
+	@echo
+	python3 test_collections_errors.py
 
 $(EXTRADIRS)::
 	@echo

--- a/tests/test_collections_errors.py
+++ b/tests/test_collections_errors.py
@@ -11,6 +11,7 @@ Usage:
     python3 tests/test_collections_errors.py -v        # verbose
     python3 tests/test_collections_errors.py -k PAT    # filter tests by name
 """
+from __future__ import annotations
 
 import argparse
 import os
@@ -39,18 +40,22 @@ class TestRunner:
         filter_pattern: Optional[str] = None,
         asy: Optional[str] = None,
         base_dir: Optional[str] = None,
+        simulate_failure: bool = False,
     ):
         self.verbose = verbose
         self.filter_pattern = filter_pattern
         self.asy = asy or _DEFAULT_ASY
         self.base_dir = base_dir or _DEFAULT_BASE_DIR
+        self.simulate_failure = simulate_failure
         self.passed = 0
         self.failed = 0
         self.skipped = 0
 
     def run_asy(self, code: str) -> tuple[str, int]:
         """Write *code* to a temp file, run asy on it, return stderr and return code."""
-        fd, tmpfile = tempfile.mkstemp(suffix=".asy", dir=SCRIPT_DIR)
+        if self.simulate_failure:
+            return "<simulated output that does not match any expected pattern>", 1
+        fd, tmpfile = tempfile.mkstemp(suffix=".asy")
         try:
             # Asy code snippets are embedded in Python triple-quoted strings
             # which inherit Python indentation. Dedent them here so the
@@ -84,22 +89,27 @@ class TestRunner:
             sys.stdout.write(f"  {name} ... ")
             sys.stdout.flush()
         actual, returncode = self.run_asy(code)
-        if returncode != 0 and re.search(expected_pattern, actual):
+        if returncode == 0 or not re.search(expected_pattern, actual):
             if self.verbose:
-                print("PASSED")
+                print("FAILED")
+                print(f"    Expected pattern: {expected_pattern!r}")
+                print(f"    Got:              {actual!r}")
+            elif not self.failed:
+                print(f"\n  {name} ... FAILED")
+                print(f"    Expected pattern: {expected_pattern!r}")
+                print(f"    Got:              {actual!r}")
             else:
-                sys.stdout.write(".")
+                sys.stdout.write("F")
                 sys.stdout.flush()
-            self.passed += 1
-            return True
+            self.failed += 1
+            return False
         if self.verbose:
-            print("FAILED")
+            print("PASSED")
         else:
-            print(f"\n  {name} ... FAILED")
-        print(f"    Expected pattern: {expected_pattern!r}")
-        print(f"    Got:              {actual!r}")
-        self.failed += 1
-        return False
+            sys.stdout.write(".")
+            sys.stdout.flush()
+        self.passed += 1
+        return True
 
     def summary(self) -> bool:
         """Print a summary line and return True iff all tests passed."""
@@ -122,22 +132,24 @@ class TestRunner:
 def run_tests(runner: TestRunner) -> None:
     # Tracks whether a non-verbose group is open (needs "PASSED" to close it).
     group_started = False
+    failures_at_group_start = 0
 
     def print_header(title: str) -> None:
-        nonlocal group_started
+        nonlocal group_started, failures_at_group_start
         to_print = f"Testing runtime errors ({title})"
         if runner.verbose:
             print(to_print)
         else:
             if group_started:
-                print("PASSED")  # close previous group, newline before next header
+                print("  FAILED" if failures_at_group_start < runner.failed else "PASSED")  # close previous group, newline before next header
             group_started = True
+            failures_at_group_start = runner.failed
             print(to_print, end="")
 
     def end_groups() -> None:
         """Close the final group without a trailing newline."""
         if not runner.verbose and group_started:
-            print("PASSED", end="")
+            print("  FAILED" if failures_at_group_start < runner.failed else "PASSED", end="")
 
     # -----------------------------------------------------------------------
     # Queue
@@ -508,6 +520,11 @@ def main() -> int:
         default=_DEFAULT_BASE_DIR,
         help="path to the asy base/sysdir (default: %(default)s)",
     )
+    parser.add_argument(
+        "--simulate-failure",
+        action="store_true",
+        help="replace asy output with non-matching text so every test fails; useful for previewing failure formatting",
+    )
     args = parser.parse_args()
 
     runner = TestRunner(
@@ -515,6 +532,7 @@ def main() -> int:
         filter_pattern=args.filter,
         asy=args.asy,
         base_dir=args.base_dir,
+        simulate_failure=args.simulate_failure,
     )
 
     print(

--- a/tests/test_collections_errors.py
+++ b/tests/test_collections_errors.py
@@ -22,8 +22,8 @@ import textwrap
 
 # One directory up from this file is the asymptote source root.
 SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-ASY = os.path.join(SCRIPT_DIR, "asy")
-BASE_DIR = os.path.join(SCRIPT_DIR, "base")
+_DEFAULT_ASY = os.path.join(SCRIPT_DIR, "asy")
+_DEFAULT_BASE_DIR = os.path.join(SCRIPT_DIR, "base")
 
 
 # ---------------------------------------------------------------------------
@@ -32,9 +32,12 @@ BASE_DIR = os.path.join(SCRIPT_DIR, "base")
 
 
 class TestRunner:
-    def __init__(self, verbose: bool = False, filter_pattern: str = None):
+    def __init__(self, verbose: bool = False, filter_pattern: str = None,
+                 asy: str = None, base_dir: str = None):
         self.verbose = verbose
         self.filter_pattern = filter_pattern
+        self.asy = asy or _DEFAULT_ASY
+        self.base_dir = base_dir or _DEFAULT_BASE_DIR
         self.passed = 0
         self.failed = 0
         self.skipped = 0
@@ -50,7 +53,7 @@ class TestRunner:
             with os.fdopen(fd, "w") as f:
                 f.write(cleaned)
             result = subprocess.run(
-                [ASY, "-q", "-noautoplain", "-sysdir", BASE_DIR, tmpfile],
+                [self.asy, "-q", "-noautoplain", "-sysdir", self.base_dir, tmpfile],
                 cwd=SCRIPT_DIR,
                 capture_output=True,
                 text=True,
@@ -461,11 +464,22 @@ def main() -> int:
         metavar="PATTERN",
         help="only run tests whose name matches PATTERN (case-insensitive regex)",
     )
+    parser.add_argument(
+        "--asy",
+        default=_DEFAULT_ASY,
+        help="path to the asy executable (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--base-dir",
+        default=_DEFAULT_BASE_DIR,
+        help="path to the asy base/sysdir (default: %(default)s)",
+    )
     args = parser.parse_args()
 
-    runner = TestRunner(verbose=args.verbose, filter_pattern=args.filter)
+    runner = TestRunner(verbose=args.verbose, filter_pattern=args.filter,
+                        asy=args.asy, base_dir=args.base_dir)
 
-    print(f"Running collections runtime error tests (asy = {ASY})\n")
+    print(f"Running collections runtime error tests (asy = {runner.asy})\n")
     run_tests(runner)
     passed = runner.summary()
     return 0 if passed else 1

--- a/tests/test_collections_errors.py
+++ b/tests/test_collections_errors.py
@@ -8,7 +8,7 @@ changes do not break the tests.
 
 Usage:
     python3 tests/test_collections_errors.py           # run all tests
-    python3 tests/test_collections_errors.py -v        # verbose (show PASSes)
+    python3 tests/test_collections_errors.py -v        # verbose
     python3 tests/test_collections_errors.py -k PAT    # filter tests by name
 """
 
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+from typing import Optional
 
 # One directory up from this file is the asymptote source root.
 SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -35,9 +36,9 @@ class TestRunner:
     def __init__(
         self,
         verbose: bool = False,
-        filter_pattern: str = None,
-        asy: str = None,
-        base_dir: str = None,
+        filter_pattern: Optional[str] = None,
+        asy: Optional[str] = None,
+        base_dir: Optional[str] = None,
     ):
         self.verbose = verbose
         self.filter_pattern = filter_pattern
@@ -47,8 +48,8 @@ class TestRunner:
         self.failed = 0
         self.skipped = 0
 
-    def run_asy(self, code: str) -> str:
-        """Write *code* to a temp file, run asy on it, and return stderr."""
+    def run_asy(self, code: str) -> tuple[str, int]:
+        """Write *code* to a temp file, run asy on it, return stderr and return code."""
         fd, tmpfile = tempfile.mkstemp(suffix=".asy", dir=SCRIPT_DIR)
         try:
             # Asy code snippets are embedded in Python triple-quoted strings
@@ -64,7 +65,7 @@ class TestRunner:
                 text=True,
                 check=False,
             )
-            return result.stderr
+            return result.stderr, result.returncode
         finally:
             os.unlink(tmpfile)
 
@@ -79,14 +80,22 @@ class TestRunner:
             self.skipped += 1
             return True
 
-        sys.stdout.write(f"  {name} ... ")
-        sys.stdout.flush()
-        actual = self.run_asy(code)
-        if re.search(expected_pattern, actual):
-            print("PASSED")
+        if self.verbose:
+            sys.stdout.write(f"  {name} ... ")
+            sys.stdout.flush()
+        actual, returncode = self.run_asy(code)
+        if returncode != 0 and re.search(expected_pattern, actual):
+            if self.verbose:
+                print("PASSED")
+            else:
+                sys.stdout.write(".")
+                sys.stdout.flush()
             self.passed += 1
             return True
-        print("FAILED")
+        if self.verbose:
+            print("FAILED")
+        else:
+            print(f"\n  {name} ... FAILED")
         print(f"    Expected pattern: {expected_pattern!r}")
         print(f"    Got:              {actual!r}")
         self.failed += 1
@@ -111,11 +120,29 @@ class TestRunner:
 
 
 def run_tests(runner: TestRunner) -> None:
+    # Tracks whether a non-verbose group is open (needs "PASSED" to close it).
+    group_started = False
+
+    def print_header(title: str) -> None:
+        nonlocal group_started
+        to_print = f"Testing runtime errors ({title})"
+        if runner.verbose:
+            print(to_print)
+        else:
+            if group_started:
+                print("PASSED")  # close previous group, newline before next header
+            group_started = True
+            print(to_print, end="")
+
+    def end_groups() -> None:
+        """Close the final group without a trailing newline."""
+        if not runner.verbose and group_started:
+            print("PASSED", end="")
 
     # -----------------------------------------------------------------------
     # Queue
     # -----------------------------------------------------------------------
-    print("Queue:")
+    print_header("Queue")
 
     runner.check(
         "pop from empty queue",
@@ -164,7 +191,7 @@ def run_tests(runner: TestRunner) -> None:
     # -----------------------------------------------------------------------
     # HashMap
     # -----------------------------------------------------------------------
-    print("HashMap:")
+    print_header("HashMap")
 
     runner.check(
         "get missing key (no nullValue)",
@@ -223,7 +250,7 @@ def run_tests(runner: TestRunner) -> None:
     # -----------------------------------------------------------------------
     # BTreeMap
     # -----------------------------------------------------------------------
-    print("BTreeMap:")
+    print_header("BTreeMap")
 
     runner.check(
         "get missing key (no nullValue)",
@@ -263,7 +290,7 @@ def run_tests(runner: TestRunner) -> None:
     # -----------------------------------------------------------------------
     # HashSet
     # -----------------------------------------------------------------------
-    print("HashSet:")
+    print_header("HashSet")
 
     runner.check(
         "get missing item (no nullT)",
@@ -322,7 +349,7 @@ def run_tests(runner: TestRunner) -> None:
     # -----------------------------------------------------------------------
     # BTreeSet  (accessed via collections.btree)
     # -----------------------------------------------------------------------
-    print("BTreeSet:")
+    print_header("BTreeSet")
 
     runner.check(
         "get missing item (no nullT)",
@@ -452,6 +479,8 @@ def run_tests(runner: TestRunner) -> None:
         r"assert FAILED: Concurrent modification",
     )
 
+    end_groups()
+
 
 # ---------------------------------------------------------------------------
 # Entry point
@@ -488,7 +517,10 @@ def main() -> int:
         base_dir=args.base_dir,
     )
 
-    print(f"Running collections runtime error tests (asy = {runner.asy})\n")
+    print(
+        f"Running collections runtime error tests (asy = {runner.asy})\n",
+        end="\n" if runner.verbose else "",
+    )
     run_tests(runner)
     passed = runner.summary()
     return 0 if passed else 1

--- a/tests/test_collections_errors.py
+++ b/tests/test_collections_errors.py
@@ -32,8 +32,13 @@ _DEFAULT_BASE_DIR = os.path.join(SCRIPT_DIR, "base")
 
 
 class TestRunner:
-    def __init__(self, verbose: bool = False, filter_pattern: str = None,
-                 asy: str = None, base_dir: str = None):
+    def __init__(
+        self,
+        verbose: bool = False,
+        filter_pattern: str = None,
+        asy: str = None,
+        base_dir: str = None,
+    ):
         self.verbose = verbose
         self.filter_pattern = filter_pattern
         self.asy = asy or _DEFAULT_ASY
@@ -476,8 +481,12 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    runner = TestRunner(verbose=args.verbose, filter_pattern=args.filter,
-                        asy=args.asy, base_dir=args.base_dir)
+    runner = TestRunner(
+        verbose=args.verbose,
+        filter_pattern=args.filter,
+        asy=args.asy,
+        base_dir=args.base_dir,
+    )
 
     print(f"Running collections runtime error tests (asy = {runner.asy})\n")
     run_tests(runner)

--- a/tests/test_collections_errors.py
+++ b/tests/test_collections_errors.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Runtime error tests for Asymptote collections data structures.
+
+The test harness runs a snippet of Asymptote code in a temporary file,
+captures stderr, and checks it against a regex pattern.  Line numbers and
+full file paths are deliberately excluded from patterns so that minor source
+changes do not break the tests.
+
+Usage:
+    python3 tests/test_collections_errors.py           # run all tests
+    python3 tests/test_collections_errors.py -v        # verbose (show PASSes)
+    python3 tests/test_collections_errors.py -k PAT    # filter tests by name
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+# One directory up from this file is the asymptote source root.
+SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ASY = os.path.join(SCRIPT_DIR, "asy")
+BASE_DIR = os.path.join(SCRIPT_DIR, "base")
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+class TestRunner:
+    def __init__(self, verbose: bool = False, filter_pattern: str = None):
+        self.verbose = verbose
+        self.filter_pattern = filter_pattern
+        self.passed = 0
+        self.failed = 0
+        self.skipped = 0
+
+    def run_asy(self, code: str) -> str:
+        """Write *code* to a temp file, run asy on it, and return stderr."""
+        fd, tmpfile = tempfile.mkstemp(suffix=".asy", dir=SCRIPT_DIR)
+        try:
+            # Asy code snippets are embedded in Python triple-quoted strings
+            # which inherit Python indentation. Dedent them here so the
+            # temporary .asy files contain nicely-formatted code for humans.
+            cleaned = textwrap.dedent(code).lstrip("\n")
+            with os.fdopen(fd, "w") as f:
+                f.write(cleaned)
+            result = subprocess.run(
+                [ASY, "-q", "-noautoplain", "-sysdir", BASE_DIR, tmpfile],
+                cwd=SCRIPT_DIR,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            return result.stderr
+        finally:
+            os.unlink(tmpfile)
+
+    def check(self, name: str, code: str, expected_pattern: str) -> bool:
+        """Run *code* and verify stderr matches *expected_pattern* (regex).
+
+        Returns True if the test passed (or was skipped), False on failure.
+        """
+        if self.filter_pattern and not re.search(
+            self.filter_pattern, name, re.IGNORECASE
+        ):
+            self.skipped += 1
+            return True
+
+        sys.stdout.write(f"  {name} ... ")
+        sys.stdout.flush()
+        actual = self.run_asy(code)
+        if re.search(expected_pattern, actual):
+            print("PASSED")
+            self.passed += 1
+            return True
+        print("FAILED")
+        print(f"    Expected pattern: {expected_pattern!r}")
+        print(f"    Got:              {actual!r}")
+        self.failed += 1
+        return False
+
+    def summary(self) -> bool:
+        """Print a summary line and return True iff all tests passed."""
+        total = self.passed + self.failed + self.skipped
+        run = total - self.skipped
+        parts = [f"{self.passed}/{run} passed"]
+        if self.failed:
+            parts.append(f"{self.failed} failed")
+        if self.skipped:
+            parts.append(f"{self.skipped} skipped")
+        print("\n" + ", ".join(parts))
+        return self.failed == 0
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+def run_tests(runner: TestRunner) -> None:
+
+    # -----------------------------------------------------------------------
+    # Queue
+    # -----------------------------------------------------------------------
+    print("Queue:")
+
+    runner.check(
+        "pop from empty queue",
+        """
+        from collections.queue(T=int) access makeQueue;
+        var q = makeQueue(new int[]);
+        q.pop();
+        """,
+        r"assert FAILED: Queue is empty",
+    )
+
+    runner.check(
+        "peek at empty queue",
+        """
+        from collections.queue(T=int) access makeQueue;
+        var q = makeQueue(new int[]);
+        q.peek();
+        """,
+        r"assert FAILED: Queue is empty",
+    )
+
+    runner.check(
+        "iterator undermined by push",
+        """
+        from collections.queue(T=int) access makeQueue;
+        var q = makeQueue(new int[]{1, 2, 3});
+        for (int x : q) {
+          q.push(99);
+        }
+        """,
+        r"assert FAILED: Iterator undermined\.",
+    )
+
+    runner.check(
+        "iterator undermined by pop",
+        """
+        from collections.queue(T=int) access makeQueue;
+        var q = makeQueue(new int[]{1, 2, 3});
+        for (int x : q) {
+          q.pop();
+        }
+        """,
+        r"assert FAILED: Iterator undermined\.",
+    )
+
+    # -----------------------------------------------------------------------
+    # HashMap
+    # -----------------------------------------------------------------------
+    print("HashMap:")
+
+    runner.check(
+        "get missing key (no nullValue)",
+        """
+        from collections.hashmap(K=string, V=int) access HashMap_K_V;
+        HashMap_K_V h;
+        int v = h["missing"];
+        """,
+        r"assert FAILED: Key not found in map",
+    )
+
+    runner.check(
+        "delete nonexistent key",
+        """
+        from collections.hashmap(K=string, V=int) access HashMap_K_V;
+        HashMap_K_V h;
+        h["a"] = 1;
+        h.delete("missing");
+        """,
+        r"assert FAILED: Nonexistent key cannot be deleted",
+    )
+
+    runner.check(
+        "iterator concurrent modification",
+        """
+        from collections.hashmap(K=string, V=int) access HashMap_K_V;
+        HashMap_K_V h;
+        h["a"] = 1;
+        h["b"] = 2;
+        for (string k : h) {
+          h["new_key"] = 99;
+        }
+        """,
+        r"assert FAILED: Concurrent modification",
+    )
+
+    runner.check(
+        "nullValue not satisfying isNullValue",
+        """
+        from collections.hashmap(K=string, V=int) access HashMap_K_V;
+        HashMap_K_V(nullValue=0, isNullValue=new bool(int v) { return v == -1; });
+        """,
+        r"assert FAILED: nullValue must satisfy isNullValue",
+    )
+
+    runner.check(
+        "randomKey from empty map",
+        """
+        from collections.hashmap(K=string, V=int) access HashMap_K_V;
+        HashMap_K_V h;
+        h.randomKey();
+        """,
+        r"assert FAILED: Cannot get a random key from an empty map",
+    )
+
+    # -----------------------------------------------------------------------
+    # BTreeMap
+    # -----------------------------------------------------------------------
+    print("BTreeMap:")
+
+    runner.check(
+        "get missing key (no nullValue)",
+        """
+        from collections.btreemap(K=string, V=int) access BTreeMap_K_V;
+        BTreeMap_K_V h;
+        int v = h["missing"];
+        """,
+        r"assert FAILED: Key not found in map",
+    )
+
+    runner.check(
+        "delete nonexistent key",
+        """
+        from collections.btreemap(K=string, V=int) access BTreeMap_K_V;
+        BTreeMap_K_V h;
+        h["a"] = 1;
+        h.delete("missing");
+        """,
+        r"assert FAILED: Nonexistent key cannot be deleted",
+    )
+
+    runner.check(
+        "iterator concurrent modification",
+        """
+        from collections.btreemap(K=string, V=int) access BTreeMap_K_V;
+        BTreeMap_K_V h;
+        h["a"] = 1;
+        h["b"] = 2;
+        for (string k : h) {
+          h["new_key"] = 99;
+        }
+        """,
+        r"assert FAILED: Concurrent modification",
+    )
+
+    # -----------------------------------------------------------------------
+    # HashSet
+    # -----------------------------------------------------------------------
+    print("HashSet:")
+
+    runner.check(
+        "get missing item (no nullT)",
+        """
+        from collections.hashset(T=int) access HashSet_T;
+        HashSet_T s;
+        s.get(42);
+        """,
+        r"assert FAILED: Item is not present\.",
+    )
+
+    runner.check(
+        "push new item (no nullT)",
+        """
+        from collections.hashset(T=int) access HashSet_T;
+        HashSet_T s;
+        s.push(42);
+        """,
+        r"assert FAILED: Adding item via push\(\) without defining nullT\.",
+    )
+
+    runner.check(
+        "extract missing item (no nullT)",
+        """
+        from collections.hashset(T=int) access HashSet_T;
+        HashSet_T s;
+        s.extract(42);
+        """,
+        r"assert FAILED: Item is not present\.",
+    )
+
+    runner.check(
+        "getRandom from empty set (no nullT)",
+        """
+        from collections.hashset(T=int) access HashSet_T;
+        HashSet_T s;
+        s.getRandom();
+        """,
+        r"assert FAILED: Cannot get a random item from an empty set",
+    )
+
+    runner.check(
+        "iterator concurrent modification",
+        """
+        from collections.hashset(T=int) access HashSet_T;
+        HashSet_T s;
+        s.add(1);
+        s.add(2);
+        for (int x : s) {
+          s.add(99);
+        }
+        """,
+        r"assert FAILED: Concurrent modification",
+    )
+
+    # -----------------------------------------------------------------------
+    # BTreeSet  (accessed via collections.btree)
+    # -----------------------------------------------------------------------
+    print("BTreeSet:")
+
+    runner.check(
+        "get missing item (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.get(42);
+        """,
+        r"assert FAILED: Item is not present\.",
+    )
+
+    runner.check(
+        "push new item (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.push(42);
+        """,
+        r"assert FAILED: Adding item via push\(\) without defining nullT\.",
+    )
+
+    runner.check(
+        "extract missing item (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.extract(42);
+        """,
+        r"assert FAILED: Item not found",
+    )
+
+    runner.check(
+        "min from empty set (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.min();
+        """,
+        r"assert FAILED: No minimum element to return",
+    )
+
+    runner.check(
+        "max from empty set (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.max();
+        """,
+        r"assert FAILED: No maximum element to return",
+    )
+
+    runner.check(
+        "popMin from empty set (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.popMin();
+        """,
+        r"assert FAILED: No minimum element to pop",
+    )
+
+    runner.check(
+        "popMax from empty set (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.popMax();
+        """,
+        r"assert FAILED: No maximum element to pop",
+    )
+
+    runner.check(
+        "after: no element strictly greater (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.add(1);
+        bs.after(5);
+        """,
+        r"assert FAILED: No element after item to return",
+    )
+
+    runner.check(
+        "before: no element strictly less (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.add(5);
+        bs.before(1);
+        """,
+        r"assert FAILED: No element before item to return",
+    )
+
+    runner.check(
+        "atOrAfter: no element >= item (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.add(1);
+        bs.atOrAfter(5);
+        """,
+        r"assert FAILED: No element after item to return",
+    )
+
+    runner.check(
+        "atOrBefore: no element <= item (no nullT)",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.add(5);
+        bs.atOrBefore(1);
+        """,
+        r"assert FAILED: No element before item to return",
+    )
+
+    runner.check(
+        "iterator concurrent modification",
+        """
+        from collections.btree(T=int) access BTreeSet_T;
+        var bs = BTreeSet_T();
+        bs.add(1);
+        bs.add(2);
+        for (int x : bs) {
+          bs.add(99);
+        }
+        """,
+        r"assert FAILED: Concurrent modification",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Runtime error tests for Asymptote collections."
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="verbose output")
+    parser.add_argument(
+        "-k",
+        "--filter",
+        metavar="PATTERN",
+        help="only run tests whose name matches PATTERN (case-insensitive regex)",
+    )
+    args = parser.parse_args()
+
+    runner = TestRunner(verbose=args.verbose, filter_pattern=args.filter)
+
+    print(f"Running collections runtime error tests (asy = {ASY})\n")
+    run_tests(runner)
+    passed = runner.summary()
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_collections_errors.py
+++ b/tests/test_collections_errors.py
@@ -11,6 +11,7 @@ Usage:
     python3 tests/test_collections_errors.py -v        # verbose
     python3 tests/test_collections_errors.py -k PAT    # filter tests by name
 """
+
 from __future__ import annotations
 
 import argparse

--- a/tests/test_collections_errors.py
+++ b/tests/test_collections_errors.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import os
 import re
 import subprocess
@@ -33,23 +34,21 @@ _DEFAULT_BASE_DIR = os.path.join(SCRIPT_DIR, "base")
 # ---------------------------------------------------------------------------
 
 
+@dataclasses.dataclass
+class _Counts:
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+
+
+@dataclasses.dataclass
 class TestRunner:
-    def __init__(
-        self,
-        verbose: bool = False,
-        filter_pattern: Optional[str] = None,
-        asy: Optional[str] = None,
-        base_dir: Optional[str] = None,
-        simulate_failure: bool = False,
-    ):
-        self.verbose = verbose
-        self.filter_pattern = filter_pattern
-        self.asy = asy or _DEFAULT_ASY
-        self.base_dir = base_dir or _DEFAULT_BASE_DIR
-        self.simulate_failure = simulate_failure
-        self.passed = 0
-        self.failed = 0
-        self.skipped = 0
+    verbose: bool = False
+    filter_pattern: Optional[str] = None
+    asy: str = _DEFAULT_ASY
+    base_dir: str = _DEFAULT_BASE_DIR
+    simulate_failure: bool = False
+    counts: _Counts = dataclasses.field(default_factory=_Counts, init=False)
 
     def run_asy(self, code: str) -> tuple[str, int]:
         """Write *code* to a temp file, run asy on it, return stderr and return code."""
@@ -82,7 +81,7 @@ class TestRunner:
         if self.filter_pattern and not re.search(
             self.filter_pattern, name, re.IGNORECASE
         ):
-            self.skipped += 1
+            self.counts.skipped += 1
             return True
 
         if self.verbose:
@@ -94,34 +93,34 @@ class TestRunner:
                 print("FAILED")
                 print(f"    Expected pattern: {expected_pattern!r}")
                 print(f"    Got:              {actual!r}")
-            elif not self.failed:
+            elif not self.counts.failed:
                 print(f"\n  {name} ... FAILED")
                 print(f"    Expected pattern: {expected_pattern!r}")
                 print(f"    Got:              {actual!r}")
             else:
                 sys.stdout.write("F")
                 sys.stdout.flush()
-            self.failed += 1
+            self.counts.failed += 1
             return False
         if self.verbose:
             print("PASSED")
         else:
             sys.stdout.write(".")
             sys.stdout.flush()
-        self.passed += 1
+        self.counts.passed += 1
         return True
 
     def summary(self) -> bool:
         """Print a summary line and return True iff all tests passed."""
-        total = self.passed + self.failed + self.skipped
-        run = total - self.skipped
-        parts = [f"{self.passed}/{run} passed"]
-        if self.failed:
-            parts.append(f"{self.failed} failed")
-        if self.skipped:
-            parts.append(f"{self.skipped} skipped")
+        total = self.counts.passed + self.counts.failed + self.counts.skipped
+        run = total - self.counts.skipped
+        parts = [f"{self.counts.passed}/{run} passed"]
+        if self.counts.failed:
+            parts.append(f"{self.counts.failed} failed")
+        if self.counts.skipped:
+            parts.append(f"{self.counts.skipped} skipped")
         print("\n" + ", ".join(parts))
-        return self.failed == 0
+        return self.counts.failed == 0
 
 
 # ---------------------------------------------------------------------------
@@ -141,15 +140,26 @@ def run_tests(runner: TestRunner) -> None:
             print(to_print)
         else:
             if group_started:
-                print("  FAILED" if failures_at_group_start < runner.failed else "PASSED")  # close previous group, newline before next header
+                print(
+                    "  FAILED"
+                    if failures_at_group_start < runner.counts.failed
+                    else "PASSED"
+                )  # close previous group, newline before next header
             group_started = True
-            failures_at_group_start = runner.failed
+            failures_at_group_start = runner.counts.failed
             print(to_print, end="")
 
     def end_groups() -> None:
         """Close the final group without a trailing newline."""
         if not runner.verbose and group_started:
-            print("  FAILED" if failures_at_group_start < runner.failed else "PASSED", end="")
+            print(
+                (
+                    "  FAILED"
+                    if failures_at_group_start < runner.counts.failed
+                    else "PASSED"
+                ),
+                end="",
+            )
 
     # -----------------------------------------------------------------------
     # Queue
@@ -523,7 +533,7 @@ def main() -> int:
     parser.add_argument(
         "--simulate-failure",
         action="store_true",
-        help="replace asy output with non-matching text so every test fails; useful for previewing failure formatting",
+        help="simulate non-matching asy output so every test fails",
     )
     args = parser.parse_args()
 

--- a/tests/test_collections_errors.py
+++ b/tests/test_collections_errors.py
@@ -527,7 +527,7 @@ def main() -> int:
         help="path to the asy executable (default: %(default)s)",
     )
     parser.add_argument(
-        "--base-dir",
+        "--asy-base-dir",
         default=_DEFAULT_BASE_DIR,
         help="path to the asy base/sysdir (default: %(default)s)",
     )
@@ -542,7 +542,7 @@ def main() -> int:
         verbose=args.verbose,
         filter_pattern=args.filter,
         asy=args.asy,
-        base_dir=args.base_dir,
+        base_dir=args.asy_base_dir,
         simulate_failure=args.simulate_failure,
     )
 


### PR DESCRIPTION
Add a python file that executes snippets of asy code and checks for expected errors. (The approach with `errortests/` can check for at most one runtime error per asy file.) Add a number of tests for behavior that is expected to produce errors in the collections library. Add missing assert in `hashset.asy`. Add asserts in `queue.asy` to give better error messages.