### PR TITLE
Prevent `slide.asy` from stretching paths horizontally

### DIFF
--- a/base/slide.asy
+++ b/base/slide.asy
@@ -28,13 +28,14 @@ if(landscape) {
 texpreamble("\paperwidth="+string(pagewidth)+"bp");
 texpreamble("\paperheight"+string(pageheight)+"bp");
 
+real whr = pagewidth/pageheight;
 size(pagewidth,pageheight,IgnoreAspect);
 picture background;
 
 real minipagemargin=1inch;
 real minipagewidth=pagewidth-2minipagemargin;
 
-transform tinv=inverse(fixedscaling((-1,-1),(1,1),currentpen));
+transform tinv=inverse(fixedscaling((-whr,-1),(whr,1),currentpen));
 
 pen itempen=fontsize(24pt);
 pen codepen=fontsize(20pt);
@@ -137,7 +138,7 @@ void reversevideo()
 {
   backgroundcolor=black;
   foregroundcolor=white;
-  fill(background,box((-1,-1),(1,1)),backgroundcolor);
+  fill(background,box((-whr,-1),(whr,1)),backgroundcolor);
   setpens(mediumred,paleblue,mediumblue);
   // Work around pdflatex bug, in which white is mapped to black!
   figuremattpen=pdf() ? cmyk(0,0,0,1/255) : white;
@@ -213,7 +214,7 @@ void newslide(bool stepping=true)
 
 bool checkposition()
 {
-  if(abs(currentposition.x) > 1 || abs(currentposition.y) > 1) {
+  if(abs(currentposition.x) > whr || abs(currentposition.y) > 1) {
     newslide();
     return false;
   }
@@ -286,7 +287,7 @@ void remark(bool center=false, string s, pair align=0, pen p=itempen,
   pair m=tinv*min(f);
   pair M=tinv*min(f);
 
-  if(abs(offset.x+M.x) > 1)
+  if(abs(offset.x+M.x) > whr)
     warning("slidetoowide","slide too wide on page "+(string) page+':\n'+
             (string) s);
 


### PR DESCRIPTION
This line in the `slide` module introduces a transformation that fits the frame of every slide into the square ranging from `(-1,-1)` to `(1,1)`:
```asymptote
transform tinv=inverse(fixedscaling((-1,-1),(1,1),currentpen));
```
At the same time, the picture is sized by `size(pagewidth,pageheight,IgnoreAspect)`, which means that all paths drawn by the user are stretched horizontally by a factor of `pagewidth/pageheight`.

I understand the benefit of having "unit coordinates" ranging from `-1` to `1` in both `x` and `y` directions, which makes it easier to place content on the slide, but as soon as the user wants to draw a circle, they have to manually correct it with `xscale(pageheight/pagewidth)`, which leads to other complications, especially if rotation (which does not commute with `xscale`) is involved.

Of course, if only text and external graphics are included in the presentation (like in the [example](https://asymptote.sourceforge.io/gallery/animations/slidemovies.pdf)), this stretching is not a concern. But I think that when typesetting presentation slides, the greatest benefit of Asymptote is the total control it gives the user of the canvas, which alternatives like LaTeX or Typst do not provide.

This behavior seems to be fixed if we create a variable like
```asymptote
real whr = pagewidth/pageheight;
```
(from "[w]idth-[h]eight [r]atio") and then use `(-whr, -1)` and `(whr, 1)` in the definition of `tinv`:
```asymptote
transform tinv=inverse(fixedscaling((-whr,-1),(whr,1),currentpen));
```

This pull request makes this change and adjusts some size checks inside `slide.asy` to use `whr` instead of `1`. I make this a draft because I'm note sure about the preferred naming, and whether pull requests of such nature are approved