### PR TITLE
Allow rendering via lavapipe in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -87,6 +87,33 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         libglfw3-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# CPU-based ("software") rendering, so the Vulkan/OpenGL renderers can produce
+# rasterized images (PNG, etc.) in a container with no GPU and no real display.
+#
+#   - mesa-vulkan-drivers: ships lavapipe, Mesa's software Vulkan driver
+#     (libvulkan_lvp.so) plus its ICD manifest
+#     /usr/share/vulkan/icd.d/lvp_icd.x86_64.json. The Vulkan loader (installed
+#     above with the LunarG SDK) picks it up; containerEnv pins VK_ICD_FILENAMES
+#     to it so device selection is deterministic. NOTE: Ubuntu 22.04's lavapipe
+#     advertises Vulkan 1.3, while asy's renderer requests 1.4 (vkrender.cc);
+#     the Vulkan export path may therefore need asy's required version relaxed.
+#   - libgl1-mesa-dri: Mesa's DRI modules, including swrast/llvmpipe -- the
+#     software OpenGL rasterizer. Already pulled in transitively by the base
+#     image, but named explicitly so it cannot silently drop out. Forced on via
+#     LIBGL_ALWAYS_SOFTWARE / GALLIUM_DRIVER in devcontainer.json.
+#   - xvfb: a virtual (headless) X server. asy's OpenGL renderer always creates
+#     a GLFW window, which needs an X display even when hidden, so headless GL
+#     export is run as `xvfb-run -a asy ...`. (Vulkan export renders to
+#     offscreen buffers and needs no display.)
+#   - mesa-utils: glxinfo / eglinfo, for diagnosing which GL renderer is active.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends \
+        mesa-vulkan-drivers \
+        libgl1-mesa-dri \
+        xvfb \
+        mesa-utils \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Mark the pre-installed vcpkg clone as a safe git directory. The base image's
 # vcpkg lives at /usr/local/vcpkg owned by root:vcpkg; the build runs as the
 # `vscode` user (a member of the vcpkg group, so it can write), but git refuses
@@ -125,4 +152,41 @@ RUN if [ "${INSTALL_DOC_DEPS}" = "true" ]; then \
             ghostscript \
             dvisvgm \
         && apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Newer Ghostscript built from source, shadowing the stock apt one on PATH.
+#
+# asy defaults its PNG output to Ghostscript's `png16malpha` device
+# (settings.pngdriver), but Ubuntu 22.04 ships Ghostscript 9.55, which predates
+# that device -- so PNG export fails with "Unknown device: png16malpha ->
+# shipout failed" unless you override `-pngdriver pngalpha`. We therefore build
+# a current Ghostscript from the pinned upstream source release and install it
+# into /usr/local (which precedes /usr/bin on PATH, like the pip CMake above),
+# so plain `gs` is the new version and the default png16malpha driver works.
+#
+# The apt `ghostscript` above is kept on purpose: it pulls in libgs (used by
+# dvisvgm) and the shared Resource/font tree. This build only replaces the `gs`
+# *binary* asy invokes; its own resources install under
+# /usr/local/share/ghostscript. Upstream publishes no generic Linux x86_64
+# binary (only a snap), hence the from-source build. Pinned + checksum-verified
+# for reproducibility; its own cached layer so it is not rebuilt on unrelated
+# changes. configure disables X/CUPS/GTK/tesseract (none needed here); it still
+# links the image's system fontconfig/freetype for font resolution.
+ARG GHOSTSCRIPT_VERSION=10.07.1
+ARG GHOSTSCRIPT_RELEASE=gs10071
+ARG GHOSTSCRIPT_SHA256=2fc74362f9be6fae1b0a65d38fdcfd4f0b518cc3b07c5581fb661eb4d2e15251
+RUN if [ "${INSTALL_DOC_DEPS}" = "true" ]; then \
+        cd /tmp \
+        && wget -q -O ghostscript.tar.gz \
+            "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/${GHOSTSCRIPT_RELEASE}/ghostscript-${GHOSTSCRIPT_VERSION}.tar.gz" \
+        && echo "${GHOSTSCRIPT_SHA256}  ghostscript.tar.gz" | sha256sum -c - \
+        && tar -xzf ghostscript.tar.gz \
+        && cd "ghostscript-${GHOSTSCRIPT_VERSION}" \
+        && ./configure --prefix=/usr/local --without-x --disable-cups \
+            --disable-gtk --without-tesseract \
+        && make -j"$(nproc)" \
+        && make install \
+        && cd /tmp \
+        && rm -rf "ghostscript-${GHOSTSCRIPT_VERSION}" ghostscript.tar.gz \
+        && gs --version; \
     fi

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -25,8 +25,17 @@ Asymptote with the CMake + vcpkg toolchain. It mirrors the Linux CI environment
   [`vcpkg.json`](../vcpkg.json) (it is owned by root but the build runs as
   `vscode`; without this, baseline resolution fails with a `git show
   versions/baseline.json` error).
+- **CPU rendering** (`Dockerfile` + `devcontainer.json`): Mesa's software
+  rasterizers are installed and forced on so the Vulkan/OpenGL renderers can
+  produce rasterized images without a GPU — `mesa-vulkan-drivers` (lavapipe) for
+  Vulkan, `libgl1-mesa-dri` (llvmpipe) for OpenGL, plus `xvfb` for the X display
+  the GL path needs. See [CPU rendering](#cpu-rendering-llvmpipe--lavapipe).
 - **Documentation toolchain:** LaTeX + Ghostscript + texinfo are baked into the
-  image (on by default) so the `docgen` target works out of the box.
+  image (on by default) so the `docgen` target works out of the box. Ubuntu
+  22.04's stock Ghostscript (9.55) is too old for asy's default `png16malpha`
+  PNG device, so the `Dockerfile` also builds a current Ghostscript from source
+  and installs it ahead of the apt one on `PATH` (see [CPU
+  rendering](#cpu-rendering-llvmpipe--lavapipe)).
 - **vcpkg dependencies** are declared in the top-level [`vcpkg.json`](../vcpkg.json)
   and are resolved automatically by CMake during configure.
 - **Python developer virtualenv** (`post-create.sh`): a venv is created at
@@ -78,6 +87,117 @@ cmake --build --preset linux/release --target docgen
 If you want a leaner image without these (they add several GB), set the
 `INSTALL_DOC_DEPS` build arg to `"false"` in
 [`devcontainer.json`](./devcontainer.json) and rebuild the container.
+
+## CPU rendering (llvmpipe / lavapipe)
+
+The container has no GPU, but it can still exercise the Vulkan and OpenGL
+renderers via Mesa's software rasterizers and write the result to a rasterized
+file (PNG, etc.). This is for *testing* the renderers — producing and inspecting
+images — not for interactive viewing.
+
+What's set up for you (see [`Dockerfile`](./Dockerfile) and
+[`devcontainer.json`](./devcontainer.json)):
+
+- **lavapipe** (`mesa-vulkan-drivers`) — Mesa's software Vulkan driver.
+  `VK_ICD_FILENAMES` is pinned to its ICD
+  (`/usr/share/vulkan/icd.d/lvp_icd.x86_64.json`) so device selection is
+  deterministic.
+- **llvmpipe** (`libgl1-mesa-dri`) — Mesa's software OpenGL rasterizer, forced
+  on with `LIBGL_ALWAYS_SOFTWARE=true` and `GALLIUM_DRIVER=llvmpipe`.
+- **xvfb** — a virtual X server, because asy's OpenGL renderer always opens a
+  (hidden) GLFW window and so needs a display. Vulkan export renders to
+  offscreen buffers and needs no display.
+
+These renderers are only present in builds configured with them. The full
+`linux/release` vcpkg build builds the **Vulkan** renderer (`libasyvulkan.so`,
+dlopened at runtime); the OpenGL renderer (`libasyopengl.so`) is built only by
+the autotools (`./configure && make`) build. The no-network `linux/sandbox`
+preset builds neither.
+
+```bash
+# Vulkan -> PNG (no display needed): renders via lavapipe.
+# Run from any directory OTHER than the workspace root (see the note below),
+# and point -dir at the build's base/ so the dlopened libasyvulkan.so is found.
+cd /tmp
+~/.local/asy-build/release/asy -dir ~/.local/asy-build/release/base \
+    -f png -render=4 -o teapot.png \
+    /workspaces/asymptote/ex/teapot
+
+# OpenGL -> PNG: wrap in xvfb-run so the GL renderer has an X display.
+# (Requires an autotools build that produced libasyopengl.so.)
+xvfb-run -a ./asy -dir ./base -novulkan -f png -render=4 -o out.png myscene.asy
+
+# Diagnostics:
+vulkaninfo 2>/dev/null | grep -m1 deviceName     # -> llvmpipe (LLVM ...)
+xvfb-run -a glxinfo | grep -E 'OpenGL renderer'  # -> llvmpipe
+```
+
+Verified working: the teapot above renders on `Device 0: llvmpipe` and writes a
+valid RGBA PNG.
+
+**Harmless `XDG_RUNTIME_DIR` warning.** On a Vulkan render you may see, once or
+twice on stderr:
+
+    error: XDG_RUNTIME_DIR not set in the environment.
+
+Despite the `error:` prefix this is **not** an asy error and **not** fatal — the
+render still succeeds and the PNG is written. The message comes from
+`libwayland`: Mesa's Vulkan WSI probes for a Wayland session during instance
+creation by calling `wl_display_connect()`, and libwayland prints this when
+`XDG_RUNTIME_DIR` is unset (any Vulkan program does it here — e.g. `vulkaninfo`
+prints the same). This container therefore sets `XDG_RUNTIME_DIR` (in
+[`devcontainer.json`](./devcontainer.json), with the directory created by
+[`post-create.sh`](./post-create.sh)), which silences it; the line above only
+appears if you unset that variable or run in an environment that lacks it (in
+which case `export XDG_RUNTIME_DIR=/tmp/runtime-vscode` makes it go away). It is
+safe to ignore.
+
+**Gotcha — Vulkan render hangs forever (the `device_select` layer).** Mesa ships
+an implicit Vulkan layer, `VK_LAYER_MESA_device_select`, that during
+`vkEnumeratePhysicalDevices()` connects to the X server named by `DISPLAY` (VS
+Code sets `DISPLAY=:0`) to learn which GPU drives the display so it can rank
+devices. This container has no working X server — only a stale
+`/tmp/.X11-unix/X0` socket with nothing behind it — so the layer's
+`xcb_wait_for_reply()` blocks in `poll()` and the render hangs indefinitely
+(intermittently, depending on the socket's state). A backtrace of the stuck
+process shows `xcb_wait_for_reply` → `libVkLayer_MESA_device_select.so` →
+`vkEnumeratePhysicalDevices` → `AsyVkRender::pickPhysicalDevice`.
+[`devcontainer.json`](./devcontainer.json) disables the layer with
+`VK_LOADER_LAYERS_DISABLE=VK_LAYER_MESA_device_select` (it has nothing to select
+anyway — `VK_ICD_FILENAMES` pins the single lavapipe device). If you hit this in
+an environment without that variable, `export
+VK_LOADER_LAYERS_DISABLE=VK_LAYER_MESA_device_select` (or `unset DISPLAY`) before
+rendering.
+
+**Gotcha — stale workspace renderer libs / current directory.** asy locates the
+renderer library through its search path, which is tried in order: the *current
+directory* first, then `-dir`, then the system dir. An autotools `make` in the
+workspace leaves `libasyvulkan.so` / `libasyopengl.so` in the repo root; built
+on the host they are usually incompatible with the container
+(`GLIBCXX_… not found`). Running the container's `asy` *from the workspace root*
+picks up those stale copies first and fails to render. Avoid this by running
+from another directory (as above), or remove the host-built
+`/workspaces/asymptote/libasy*.so`. The relocatable build installs its own
+`libasyvulkan.so` into `~/.local/asy-build/release/base/`, so `-dir <that base>`
+finds the correct one from any non-workspace directory.
+
+**PNG driver.** asy defaults to the Ghostscript `png16malpha` device, which
+Ubuntu 22.04's stock Ghostscript (9.55) does not provide (`Unknown device:
+png16malpha` → `shipout failed`). The `Dockerfile` builds a current Ghostscript
+from source and puts it ahead of the apt one on `PATH`, so the default driver
+works and no `-pngdriver` override is needed. (This newer `gs` is part of the
+doc toolchain, so it is present only when `INSTALL_DOC_DEPS=true`, the default;
+without it the image has no `gs` at all and PNG export is unavailable. If you
+ever do hit a `png16malpha` error, fall back with `-pngdriver pngalpha` or
+`settings.pngdriver="pngalpha";`.)
+
+**Note (Vulkan version).** asy requests Vulkan 1.4
+(`apiVersion=VK_API_VERSION_1_4` in `vkrender.cc`, VMA configured for 1.4) while
+Ubuntu 22.04's lavapipe advertises 1.3. In practice this works — the loader
+tolerates an application requesting a higher API version than the device — and
+rendering succeeds on lavapipe. If a future change makes asy hard-require 1.4
+device features, install modern Mesa from the `kisak-mesa` PPA (the Linux
+analogue of building Mesa from source as `doc/lavapipe.txt` does on macOS).
 
 ## Using this without VS Code
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,44 @@
     // This also relocates the top-level config file to
     // $CLAUDE_CONFIG_DIR/.claude.json (instead of ~/.claude.json), so the
     // login/auth lands *inside* the volume and survives rebuilds too.
-    "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
+    "CLAUDE_CONFIG_DIR": "/home/vscode/.claude",
+
+    // CPU-based ("software") rendering for the Vulkan/OpenGL renderers, so they
+    // can rasterize images on a machine with no GPU. The drivers themselves are
+    // installed in the Dockerfile (mesa-vulkan-drivers = lavapipe for Vulkan,
+    // libgl1-mesa-dri = llvmpipe for OpenGL).
+    //
+    // OpenGL: force Mesa to use the llvmpipe software rasterizer instead of
+    // probing for (absent) hardware. Note that asy's OpenGL renderer still
+    // needs an X display -- run it under `xvfb-run -a` (xvfb is installed).
+    "LIBGL_ALWAYS_SOFTWARE": "true",
+    "GALLIUM_DRIVER": "llvmpipe",
+    // Vulkan: pin the loader to lavapipe's ICD so device selection is
+    // deterministic (mesa-vulkan-drivers also installs the radv/anv ICDs, which
+    // enumerate zero devices here). Vulkan export needs no display.
+    "VK_ICD_FILENAMES": "/usr/share/vulkan/icd.d/lvp_icd.x86_64.json",
+    // There is no Wayland session in this container, but Mesa's Vulkan WSI (and
+    // the VK_LAYER_MESA_device_select layer) still probe for one during instance
+    // creation by calling wl_display_connect(). With XDG_RUNTIME_DIR unset,
+    // libwayland prints a spurious, scary-looking
+    //   error: XDG_RUNTIME_DIR not set in the environment.
+    // to stderr on every Vulkan render (it is harmless -- offscreen export does
+    // not need a display and succeeds anyway). Pointing XDG_RUNTIME_DIR at a
+    // directory silences it; post-create.sh creates this one with mode 0700 so
+    // it is also a valid runtime dir for anything that genuinely uses it.
+    "XDG_RUNTIME_DIR": "/tmp/runtime-vscode",
+    // Disable Mesa's implicit "device select" Vulkan layer. During
+    // vkEnumeratePhysicalDevices() it connects to the X server named by DISPLAY
+    // (set to :0 here, e.g. by VS Code) to find which GPU drives the display so
+    // it can rank devices. This container has no working X server -- only a
+    // stale /tmp/.X11-unix/X0 socket with nothing behind it -- so the layer's
+    // xcb_wait_for_reply() blocks forever in poll() and a Vulkan render hangs
+    // (intermittently, depending on the socket's state). With VK_ICD_FILENAMES
+    // pinned to the single lavapipe device above there is nothing to select, so
+    // the layer is pure liability; the Vulkan loader honours this filter and
+    // force-disables it. (We leave DISPLAY alone so X forwarding still works for
+    // anyone who does have a host X server / GUI apps.)
+    "VK_LOADER_LAYERS_DISABLE": "VK_LAYER_MESA_device_select"
   },
 
   // Set the TZ environment variable whenever connecting to the container.
@@ -73,9 +110,12 @@
         "cmake.useCMakePresets": "always",
         // Use the container-owned virtualenv built by post-create.sh (kept out
         // of the bind-mounted workspace so it never clashes with the host's
-        // ./venv). VS Code activates it automatically in integrated terminals.
+        // ./venv). The venv is activated synchronously by ~/.bashrc (see
+        // post-create.sh), so the extension's own activation is disabled: it
+        // injects asynchronously and prefixes a Ctrl-C to clear the line, which
+        // can interrupt a long-running command (e.g. a build) in the terminal.
         "python.defaultInterpreterPath": "/home/vscode/.venv/asymptote/bin/python",
-        "python.terminal.activateEnvironment": true
+        "python.terminal.activateEnvironment": false
       }
     }
   },

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -32,6 +32,21 @@ if [ -n "$VCPKG_BASELINE" ] \
 fi
 
 # ---------------------------------------------------------------------------
+# Runtime dir for the (absent) Wayland session.
+#
+# devcontainer.json sets XDG_RUNTIME_DIR=/tmp/runtime-vscode to silence the
+# spurious "XDG_RUNTIME_DIR not set in the environment." that Mesa's Vulkan WSI
+# triggers via libwayland on every render. Create the directory it points at
+# with the mode 0700 the XDG spec mandates so it is a valid runtime dir for
+# anything that actually uses it. Skip if XDG_RUNTIME_DIR is unset (nothing to
+# create).
+# ---------------------------------------------------------------------------
+if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+    mkdir -p "$XDG_RUNTIME_DIR"
+    chmod 700 "$XDG_RUNTIME_DIR"
+fi
+
+# ---------------------------------------------------------------------------
 # Python developer virtualenv.
 #
 # Deliberately created OUTSIDE the bind-mounted workspace: the repo's own
@@ -48,8 +63,10 @@ fi
 "$VENV_DIR/bin/pip" install -r requirements-dev.txt
 
 # Auto-activate the venv in interactive bash shells (terminals opened in the
-# container). VS Code also activates it automatically for tasks/debugging via
-# python.terminal.activateEnvironment.
+# container). This is the sole activation path: the VS Code Python extension's
+# own terminal activation (python.terminal.activateEnvironment) is disabled in
+# devcontainer.json because it injects asynchronously and sends a Ctrl-C first,
+# which can interrupt a long-running command in the terminal.
 ACTIVATE_LINE="source \"$VENV_DIR/bin/activate\""
 if ! grep -qsF "$ACTIVATE_LINE" "$HOME/.bashrc"; then
     {

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,11 @@
 # default behavior for all files
 * text=auto
 
+# Shell scripts must keep LF endings: they are executed under /bin/sh in the
+# Linux devcontainer, where a trailing CR makes bash misread e.g.
+# `set -euo pipefail` as the invalid option `pipefail\r`.
+*.sh text eol=lf
+
 config.sub text eol=lf
 config.guess text eol=lf
 *.in text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,24 +73,56 @@ target_link_libraries(asycore PUBLIC ${ASY_STATIC_LIBRARIES})
 target_compile_definitions(asycore PUBLIC ${ASY_MACROS})
 target_compile_options(asycore PUBLIC ${ASY_COMPILE_OPTS})
 
-# CTAN variant of settings.cc: compiled separately with ASYMPTOTE_SYSDIR=""
-# and CTAN_BUILD defined.  The normal asy.exe uses the settings.cc already
-# compiled into asycore (with ASYMPTOTE_SYSDIR="NUL" on Windows).
-add_library(settings_obj_ctan OBJECT ${ASY_SRC_DIR}/settings.cc)
-target_link_libraries(settings_obj_ctan PRIVATE asycore)
-target_compile_definitions(settings_obj_ctan PRIVATE ASYMPTOTE_SYSDIR="" CTAN_BUILD)
-target_compile_options(settings_obj_ctan PRIVATE ${ASY_COMPILE_OPTS})
+# settings.cc bakes in ASYMPTOTE_SYSDIR, which differs per binary, so it is
+# compiled per-executable as an OBJECT library rather than into the shared
+# asycore (which is whole-archived into the executables below -- a single shared
+# copy would collide with these objects). Each variant inherits asycore's
+# include dirs / macros / options via the PRIVATE link; any extra args become
+# build-specific compile definitions.
+function(add_settings_obj target)
+    add_library(${target} OBJECT ${ASY_SRC_DIR}/settings.cc)
+    target_link_libraries(${target} PRIVATE asycore)
+    target_compile_options(${target} PRIVATE ${ASY_COMPILE_OPTS})
+    target_compile_definitions(${target} PRIVATE ${ARGN})
+endfunction()
 
-# asy executable (normal installer build, uses settings from asycore)
+#   settings_obj      -- normal binary (default ASYMPTOTE_SYSDIR, "NUL" on Win)
+#   settings_obj_ctan -- CTAN/TeXLive binary (ASYMPTOTE_SYSDIR="", CTAN_BUILD)
+add_settings_obj(settings_obj)
+add_settings_obj(settings_obj_ctan ASYMPTOTE_SYSDIR="" CTAN_BUILD)
+
+# asy executable (normal installer build)
 add_executable(
-        asy ${ASY_SRC_DIR}/main.cc ${ASY_WIN_RC_FILE}
+        asy ${ASY_SRC_DIR}/main.cc ${ASY_WIN_RC_FILE} $<TARGET_OBJECTS:settings_obj>
 )
-
-target_link_libraries(asy PUBLIC asycore)
 
 # asy-ctan executable (CTAN/TexLive build with ASYMPTOTE_SYSDIR="")
 add_executable(asy-ctan ${ASY_SRC_DIR}/main.cc ${ASY_WIN_RC_FILE} $<TARGET_OBJECTS:settings_obj_ctan>)
-target_link_libraries(asy-ctan PUBLIC asycore)
+
+# Link asycore into both executables. On Unix the renderer libraries
+# (libasyvulkan.so / libasyopengl.so) are dlopened at runtime
+# (rendererloader.cc) and resolve a large set of symbols -- camp::AsyRender,
+# camp::IEXRFile, etc. -- from the loading binary rather than compiling them in.
+# Two things are required for that to work, both mirroring the autotools build
+# (which links every object file into asy with -rdynamic):
+#
+#   1. WHOLE_ARCHIVE: asycore is a static library, so a normal link pulls in
+#      only the objects main.cc happens to reference -- the renderer's other
+#      dependencies would be dropped and dlopen would fail with "undefined
+#      symbol: ...". Force the whole archive in so every symbol is present.
+#   2. ENABLE_EXPORTS: adds --export-dynamic (-rdynamic) so those symbols land
+#      in the executable's dynamic symbol table where the dlopened libraries
+#      can bind to them.
+#
+# Applied to asy-ctan as well so the CTAN/TeXLive binary can render too.
+foreach(asy_exe asy asy-ctan)
+    if (UNIX AND NOT WIN32)
+        target_link_libraries(${asy_exe} PUBLIC "$<LINK_LIBRARY:WHOLE_ARCHIVE,asycore>")
+        set_target_properties(${asy_exe} PROPERTIES ENABLE_EXPORTS ON)
+    else()
+        target_link_libraries(${asy_exe} PUBLIC asycore)
+    endif()
+endforeach()
 
 # base files
 include(cmake-scripts/asy-base-files.cmake)

--- a/cmake-scripts/asy-files.cmake
+++ b/cmake-scripts/asy-files.cmake
@@ -1,6 +1,11 @@
 set(ASYMPTOTE_INCLUDES ${ASY_INCLUDE_DIR})
+# Note: settings.cc is intentionally NOT in this list. It bakes in
+# ASYMPTOTE_SYSDIR, which differs per binary (normal vs CTAN), so it is compiled
+# as a per-executable object library (settings_obj / settings_obj_ctan) rather
+# than into the shared asycore. Keeping it out of asycore also lets asycore be
+# whole-archived into the executables without colliding with those objects.
 set(CAMP_BUILD_FILES
-        camperror path drawpath drawlabel picture psfile texfile util settings
+        camperror path drawpath drawlabel picture psfile texfile util
         guide flatguide knot drawfill path3 drawpath3 drawsurface
         beziercurve bezierpatch pen pipestream
 )
@@ -28,8 +33,22 @@ set(CORE_BUILD_FILES
         Delaunay predicates jsfile v3dfile EXRFiles
         lspserv symbolmaps win32helpers win32pipestream
         win32xdr xstream
-        glfw renderBase vkrender vkutils vkdispatchstorage rendererloader norender
+        glfw renderBase rendererloader norender
         lspdec lspexp lspfundec lspstm
 )
+
+# Vulkan renderer sources. On a Unix Vulkan build these are compiled
+# exclusively into the dlopened libasyvulkan.so (see
+# cmake-scripts/renderer-shared-libs.cmake), so they must NOT also go into
+# asycore: doing so pulls glslang into the main binary, whose bison parser
+# collides with asymptote's own (`multiple definition of yydebug`) once asycore
+# is whole-archived into asy.
+#
+# Everywhere else they belong in the core build: on Windows (including Cygwin)
+# Vulkan is linked directly into the binary, and when Vulkan is disabled there
+# is no separate # renderer library to hold them.
+if (WIN32 OR NOT UNIX OR NOT ENABLE_VULKAN)
+    list(APPEND CORE_BUILD_FILES vkrender vkutils vkdispatchstorage)
+endif()
 
 set(ASY_CSV_ENUM_FILES v3dtypes v3dheadertypes)

--- a/cmake-scripts/linux-install.cmake
+++ b/cmake-scripts/linux-install.cmake
@@ -63,6 +63,16 @@ install(
 )
 #endregion
 
+#region renderer shared libraries
+# Build and install the runtime-dlopened renderer shared libraries
+# (libasyvulkan.so). On Unix the main asy binary loads these via dlopen at
+# runtime (rendererloader.cc); without this include the library is never built
+# and 3D rendering fails with "No 3D rendering available". Included here, after
+# ASY_INSTALL_SYSDIR_VALUE / ASY_BASE_INSTALL_COMPONENT are defined, as the
+# header of renderer-shared-libs.cmake documents.
+include(cmake-scripts/renderer-shared-libs.cmake)
+#endregion
+
 #region example files
 set(ASYMPTOTE_EXAMPLESDIR_VALUE ${ASY_INSTALL_SYSDIR_VALUE}/examples)
 

--- a/cmake-scripts/renderer-shared-libs.cmake
+++ b/cmake-scripts/renderer-shared-libs.cmake
@@ -1,0 +1,88 @@
+# renderer-shared-libs.cmake
+#
+# Builds libasyvulkan.so (and optionally libasyopengl.so) for Unix platforms.
+# On Unix the main asy binary carries zero link-time Vulkan/OpenGL dependencies;
+# instead it calls dlopen("libasyvulkan.so") at runtime via rendererloader.cc.
+# This mirrors the autotools SHIMLIBS / "libasyvulkan.so" target.
+#
+# Included from linux-install.cmake, so ASY_BASE_INSTALL_COMPONENT and
+# ASY_INSTALL_SYSDIR_VALUE are already defined.
+
+if (NOT UNIX OR WIN32)
+    return()
+endif()
+
+# ── libasyvulkan.so ──────────────────────────────────────────────────────────
+
+if (ENABLE_VULKAN)
+    # The renderer links the glslang:: imported targets (glslang::glslang,
+    # glslang::SPIRV). The main asy binary pulls glslang in via
+    # find_package(Vulkan COMPONENTS glslang) (-> Vulkan::glslang), which does
+    # not define the glslang:: targets, so request the standalone glslang CONFIG
+    # package here. It resolves from the same vcpkg tree already on the prefix
+    # path.
+    find_package(glslang CONFIG REQUIRED)
+
+    # Source set mirrors the autotools VULKAN_OBJS. EXRFiles, renderBase and the
+    # other shared renderer code are compiled into asycore (the main binary) and
+    # resolved from there at dlopen time via the binary's exported symbols (see
+    # ENABLE_EXPORTS on the asy target), so they are deliberately NOT compiled
+    # into the library a second time.
+    add_library(asyvulkan SHARED
+        ${ASY_SRC_DIR}/vkrender.cc
+        ${ASY_SRC_DIR}/vkdispatchstorage.cc
+        ${ASY_SRC_DIR}/vkutils.cc
+        ${ASY_SRC_DIR}/vulkanshim.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty_impl/vk-mem-allocator_impl/src/vma_impl.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty_impl/vk-mem-allocator_impl/src/vma_cxx.cc
+    )
+
+    # CMake automatically adds the "lib" prefix and ".so" suffix → libasyvulkan.so
+    #
+    # Build the library into the assembled base directory (the same place the
+    # base/*.asy files are staged). At runtime the loader finds it through the
+    # Asymptote search path via settings::locateFile; placing it alongside the
+    # base files makes `asy -dir <base>` resolve it from any working directory,
+    # mirroring the installed layout (where it lands in the sysdir next to base).
+    # Otherwise it would only be found when the current directory happened to be
+    # the build root.
+    set_target_properties(asyvulkan PROPERTIES
+        OUTPUT_NAME asyvulkan
+        POSITION_INDEPENDENT_CODE ON
+        LIBRARY_OUTPUT_DIRECTORY ${ASY_BUILD_BASE_DIR}
+    )
+
+    target_include_directories(asyvulkan PRIVATE
+        # Pull in asycore's full include set (includes GC headers from the gc subrepo target).
+        $<TARGET_PROPERTY:asycore,INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:vk-mem-allocator-impl,INCLUDE_DIRECTORIES>
+    )
+
+    # Same macro set as asycore (includes HAVE_LIBVULKAN, HAVE_LIBGLFW, etc.)
+    # No -DFOR_SHARED: the renderer is not a Python bindings library.
+    target_compile_definitions(asyvulkan PRIVATE ${ASY_MACROS})
+    target_compile_options(asyvulkan PRIVATE ${ASY_COMPILE_OPTS})
+
+    target_link_libraries(asyvulkan PRIVATE
+        Vulkan::Vulkan
+        glslang::glslang
+        glslang::SPIRV
+        glfw
+    )
+
+    # Generated headers (e.g. asy-keywords.h) must exist before compilation.
+    add_dependencies(asyvulkan asy_gen_headers)
+
+    # Pull libasyvulkan.so into the default ALL build via asy-with-basefiles.
+    add_dependencies(asy-with-basefiles asyvulkan)
+
+    install(
+        TARGETS asyvulkan
+        LIBRARY
+            DESTINATION ${ASY_INSTALL_SYSDIR_VALUE}
+            COMPONENT   ${ASY_BASE_INSTALL_COMPONENT}
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE
+    )
+endif()

--- a/cxxtests/CMakeLists.txt
+++ b/cxxtests/CMakeLists.txt
@@ -9,7 +9,10 @@ include(${TEST_CXX_SRC_ROOT}/cmake-scripts/tests.cmake)
 
 # test target
 
-add_executable(asyCxxTests ${ASY_TEST_SOURCES} ${TEST_CXX_SRC_ROOT}/src/testMain.cc)
+# settings.cc is no longer part of asycore (it is a per-binary OBJECT library);
+# pull in the normal settings_obj so the test binary resolves settings symbols.
+add_executable(asyCxxTests ${ASY_TEST_SOURCES} ${TEST_CXX_SRC_ROOT}/src/testMain.cc
+        $<TARGET_OBJECTS:settings_obj>)
 target_include_directories(
         asyCxxTests
         PRIVATE ${TEST_CXX_SRC_ROOT}/include

--- a/main.cc
+++ b/main.cc
@@ -81,8 +81,10 @@ int _matherr(struct _exception *except)
 
 #include "renderBase.h"
 
-pthread_mutex_t main_wait_mutex = PTHREAD_MUTEX_INITIALIZER;
-pthread_cond_t main_wait_cond = PTHREAD_COND_INITIALIZER;
+// Defined in rendererloader.cc (part of asycore) so that test executables
+// linking asycore without main.cc can resolve them as well.
+extern pthread_mutex_t main_wait_mutex;
+extern pthread_cond_t main_wait_cond;
 
 using namespace settings;
 

--- a/rendererloader.cc
+++ b/rendererloader.cc
@@ -35,8 +35,11 @@
 #include "renderBase.h"
 #include "norender.h"
 
-extern pthread_mutex_t main_wait_mutex;
-extern pthread_cond_t main_wait_cond;
+// Defined here (in asycore) rather than in main.cc so that executables which
+// link asycore without main.cc (e.g. asyCxxTests) still resolve these symbols,
+// which are referenced from picture.cc and below.
+pthread_mutex_t main_wait_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t main_wait_cond = PTHREAD_COND_INITIALIZER;
 
 #ifdef _WIN32
 #include "vkrender.h"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
 black~=26.3.1
 isort~=5.13.2
 pylint~=3.3.1
+# Required by the libsystemd vcpkg port's meson build at configure time
+# (linux/release preset); not a linting tool.
+jinja2~=3.1.6


### PR DESCRIPTION
Allow rendering via lavapipe or llvmpipe in devcontainer. Also set up the linux Cmake build to allow usage of libasyvulkan.so.