### PR TITLE
Fix workflow caching to (hopefully) speed up CI testing.

### DIFF
--- a/.github/actions/initialize-linux-env/action.yml
+++ b/.github/actions/initialize-linux-env/action.yml
@@ -38,16 +38,13 @@ runs:
       uses: actions/cache@v4
       with:
         path: /home/runner/.ccache
-        # The key must be unique per run *and* per job. github.run_id forces a
-        # cache miss each run so the freshly populated ccache is always saved
-        # (a constant key would only ever save on the first run, leaving the
-        # cache frozen). github.job keeps jobs from colliding: this composite
-        # action runs in several Linux jobs sharing one run_id, and an earlier
-        # job (e.g. configure) finishing first would otherwise claim the key and
-        # make the main build job's post-step skip saving its richer cache.
-        # restore-keys first prefers this job's own lineage, then any Linux
-        # ccache, so a new job/first run still warms from an existing cache.
-        key: ${{ runner.os }}-ccache-${{ github.job }}-${{ github.run_id }}
+        # The key must be unique per commit *and* per job. github.sha refreshes
+        # the cache whenever code changes (avoiding unbounded cache growth from a
+        # per-run key). github.job keeps jobs from colliding: this composite
+        # action runs in several Linux jobs, and an earlier job (e.g. configure)
+        # finishing first would otherwise claim the key and make the main build
+        # job's post-step skip saving its richer cache.
+        key: ${{ runner.os }}-ccache-${{ github.job }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-ccache-${{ github.job }}-
           ${{ runner.os }}-ccache-

--- a/.github/actions/initialize-linux-env/action.yml
+++ b/.github/actions/initialize-linux-env/action.yml
@@ -38,10 +38,16 @@ runs:
       uses: actions/cache@v4
       with:
         path: /home/runner/.ccache
-        # A rolling key (unique per run) forces a cache miss so the freshly
-        # populated ccache is always saved; restore-keys restores the newest
-        # prior cache. A constant key would only ever save on the first run,
-        # leaving the compile cache frozen and increasingly stale.
-        key: ${{ runner.os }}-ccache-${{ github.run_id }}
+        # The key must be unique per run *and* per job. github.run_id forces a
+        # cache miss each run so the freshly populated ccache is always saved
+        # (a constant key would only ever save on the first run, leaving the
+        # cache frozen). github.job keeps jobs from colliding: this composite
+        # action runs in several Linux jobs sharing one run_id, and an earlier
+        # job (e.g. configure) finishing first would otherwise claim the key and
+        # make the main build job's post-step skip saving its richer cache.
+        # restore-keys first prefers this job's own lineage, then any Linux
+        # ccache, so a new job/first run still warms from an existing cache.
+        key: ${{ runner.os }}-ccache-${{ github.job }}-${{ github.run_id }}
         restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.job }}-
           ${{ runner.os }}-ccache-

--- a/.github/actions/initialize-linux-env/action.yml
+++ b/.github/actions/initialize-linux-env/action.yml
@@ -28,10 +28,20 @@ runs:
       uses: actions/cache@v4
       with:
         path: /home/runner/.cache/vcpkg/archives
-        key: ${{ runner.os }}-vcpkg-cache
+        # Key on the manifest so new/changed dependencies get re-cached; the
+        # restore-keys prefix falls back to the most recent compatible cache.
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-
     - name: Cache ccache
       id: cache-ccache
       uses: actions/cache@v4
       with:
         path: /home/runner/.ccache
-        key: ${{ runner.os }}-ccache-cache
+        # A rolling key (unique per run) forces a cache miss so the freshly
+        # populated ccache is always saved; restore-keys restores the newest
+        # prior cache. A constant key would only ever save on the first run,
+        # leaving the compile cache frozen and increasingly stale.
+        key: ${{ runner.os }}-ccache-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-

--- a/.github/actions/initialize-windows-env/action.yml
+++ b/.github/actions/initialize-windows-env/action.yml
@@ -12,7 +12,11 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~\AppData\Local\vcpkg\archives
-        key: ${{ runner.os }}-vcpkg-cache
+        # Key on the manifest so new/changed dependencies get re-cached; the
+        # restore-keys prefix falls back to the most recent compatible cache.
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-
 
     - name: Create vcpkg overlay for getopt-win32
       shell: pwsh

--- a/.github/workflows/pull-req-precheck.yml
+++ b/.github/workflows/pull-req-precheck.yml
@@ -1,4 +1,4 @@
-name: pull-request-precheck
+name: ci-build-test-package
 
 on:
   pull_request:

--- a/.github/workflows/pull-req-precheck.yml
+++ b/.github/workflows/pull-req-precheck.yml
@@ -5,16 +5,26 @@ on:
     branches:
       - "master"
       - "a/*"
+  # Also run on pushes to master so the build jobs populate the ccache/vcpkg
+  # caches in master's cache scope. GitHub only lets a PR restore caches from
+  # its own ref or the base/default branch, so without this every new PR's
+  # first run would start cold.
+  push:
+    branches:
+      - "master"
 
 jobs:
   misc-sanity-checks:
     uses: ./.github/workflows/misc-sanity-checks.yml
     with:
-      target-branch: ${{ github.base_ref }}
+      # On push events github.base_ref is empty; fall back to the pushed branch
+      # (diffing master against itself yields no changed files, so the diff-based
+      # lint jobs simply find nothing to do rather than erroring).
+      target-branch: ${{ github.base_ref || github.ref_name }}
   asygl-sanity:
     uses: ./.github/workflows/asygl-sanity.yml
     with:
-      target-branch: ${{ github.base_ref }}
+      target-branch: ${{ github.base_ref || github.ref_name }}
   determine_asy_version:
     runs-on: ubuntu-22.04
     outputs:

--- a/LspCpp/.github/actions/initialize-linux-env/action.yaml
+++ b/LspCpp/.github/actions/initialize-linux-env/action.yaml
@@ -1,5 +1,15 @@
 name: initialize-env
 description: Initialize environment
+inputs:
+  cache-key-suffix:
+    description: >-
+      Extra token folded into the cache keys so parallel matrix legs (e.g.
+      with-gc / without-gc) get distinct keys. All matrix variations of a job
+      share the same github.job, so without this the first leg to finish claims
+      the key and the others skip saving their differently-compiled caches.
+      Pass the matrix value (e.g. ${{ matrix.with_gc }}) from the caller.
+    required: false
+    default: ""
 runs:
   using: 'composite'
   steps:
@@ -21,10 +31,22 @@ runs:
       uses: actions/cache@v4
       with:
         path: /home/runner/.cache/vcpkg/archives
-        key: ${{ runner.os }}-vcpkg-cache
+        # Key on the manifest so changed dependencies get re-cached; the suffix
+        # separates matrix legs (the bdwgc feature changes the installed dep
+        # set). restore-keys falls back within the leg, then to any Linux cache.
+        key: ${{ runner.os }}-vcpkg-${{ inputs.cache-key-suffix }}-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-${{ inputs.cache-key-suffix }}-
+          ${{ runner.os }}-vcpkg-
     - name: Cache ccache
       id: cache-ccache
       uses: actions/cache@v4
       with:
         path: /home/runner/.ccache
-        key: ${{ runner.os }}-ccache-cache
+        # github.sha refreshes the cache per commit; github.job plus the matrix
+        # suffix keep sibling jobs and matrix legs from colliding (an earlier
+        # finisher would otherwise claim the key and suppress the others' saves).
+        key: ${{ runner.os }}-ccache-${{ github.job }}-${{ inputs.cache-key-suffix }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.job }}-${{ inputs.cache-key-suffix }}-
+          ${{ runner.os }}-ccache-${{ github.job }}-

--- a/LspCpp/.github/actions/initialize-windows-env/action.yml
+++ b/LspCpp/.github/actions/initialize-windows-env/action.yml
@@ -1,5 +1,15 @@
 name: initialize-env
 description: Initialize environment
+inputs:
+  cache-key-suffix:
+    description: >-
+      Extra token folded into the cache keys so parallel matrix legs (e.g.
+      with-gc / without-gc) get distinct keys. All matrix variations of a job
+      share the same github.job, so without this the first leg to finish claims
+      the key and the others skip saving their differently-compiled caches.
+      Pass the matrix value (e.g. ${{ matrix.with_gc }}) from the caller.
+    required: false
+    default: ""
 runs:
   using: 'composite'
   steps:
@@ -11,7 +21,13 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~\AppData\Local\vcpkg\archives
-        key: ${{ runner.os }}-vcpkg-cache
+        # Key on the manifest so changed dependencies get re-cached; the suffix
+        # separates matrix legs (the bdwgc feature changes the installed dep
+        # set). restore-keys falls back within the leg, then to any cache.
+        key: ${{ runner.os }}-vcpkg-${{ inputs.cache-key-suffix }}-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-${{ inputs.cache-key-suffix }}-
+          ${{ runner.os }}-vcpkg-
     - name: Set environment variables
       shell: pwsh
       run: |

--- a/LspCpp/.github/workflows/build-lsp-linux.yaml
+++ b/LspCpp/.github/workflows/build-lsp-linux.yaml
@@ -13,6 +13,8 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/initialize-linux-env
+        with:
+          cache-key-suffix: ${{ matrix.with_gc }}
       - name: Add gc option to cmake build
         if: ${{ matrix.with_gc == 'with-gc' }}
         run: |

--- a/LspCpp/.github/workflows/build-lsp-windows.yaml
+++ b/LspCpp/.github/workflows/build-lsp-windows.yaml
@@ -13,6 +13,8 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/initialize-windows-env
+        with:
+          cache-key-suffix: ${{ matrix.with_gc }}
       - name: Add gc option to cmake build
         if: ${{ matrix.with_gc == 'with-gc' }}
         run: |


### PR DESCRIPTION
As I understand it, the ccache was never refreshed. Hopefully, this fix, by allowing the cache to be refreshed, should make things faster.

Additionally, this PR will cause the CI workflow to run whenever changes are pushed to master. This fixes a longstanding irritant that changes to master had to be merged into a dev branch with a PR to trigger testing. Its relevance to this PR is that the first run in a new PR can only consult the master's cache, not caches of sibling PRs; so there needs to be some way of triggering the CI workflow on the master branch, otherwise the first run will always be slow.