### PR TITLE
docs: fix Title Case heading, H2 section level, and subject-verb agreement in INSTALL-VCPKG.md

### DIFF
--- a/INSTALL-VCPKG.md
+++ b/INSTALL-VCPKG.md
@@ -1,6 +1,6 @@
 # Building Asymptote with VCPKG and CMake
 
-## Dependency management
+## Dependency Management
 
 The recommended way is to use [vcpkg](https://vcpkg.io/). Clone vcpkg to your system, run bootstrap script and ensure
 `VCPKG_ROOT` environment is exported as set as path to your vcpkg repository. For example,
@@ -11,12 +11,12 @@ git clone https://github.com/microsoft/vcpkg.git
 cd vcpkg && ./bootstrap-vcpkg.sh
 export VCPKG_ROOT=~/dev/vcpkg
 ```
-# On Windows
+## On Windows
 See INSTALL-WIN.md for windows-specific instructions.
 
 ## Linux-specific dependency (Experimental)
 
-Make sure flex and bison is available in path, if not, install them manually first.
+Make sure flex and bison are available in PATH, if not, install them manually first.
 
 ```bash
 # This is specific to arch linux, other distributions might use a different name


### PR DESCRIPTION
## Description
This PR fixes section heading capitalization, heading level, and subject-verb agreement in `INSTALL-VCPKG.md`.

## Details
1. Capitalized section header (`## Dependency management` -> `## Dependency Management`).
2. Corrected section header level (`# On Windows` -> `## On Windows`).
3. Fixed subject-verb agreement and path variable capitalization (`flex and bison is available in path` -> `flex and bison are available in PATH`).