### PR TITLE
docs: fix Title Case section headings in MAINTAINER-LICENSE-GUIDE.md

### DIFF
--- a/INSTALL-WIN.md
+++ b/INSTALL-WIN.md
@@ -5,7 +5,7 @@
 ### Required Dependencies
 Ensure the following is installed:
 - Visual Studio 2022+ or Visual Studio 2022+ build tools.
-  - Both can be found at [here](https://visualstudio.microsoft.com/downloads/).
+  - Both can be found [here](https://visualstudio.microsoft.com/downloads/).
 - CMake
   - (Recommended way) Visual Studio/Visual Studio Build Tools provides bundled CMake as a selectable component
   - Otherwise, CMake can be found [here](https://cmake.org/)
@@ -48,11 +48,11 @@ This script automatically checks that you have vcpkg, and if not, clones and boo
 Additionally, this script automatically locates your Visual Studio installation and
 establishes all required environment variables.
 
-## Notes on Dependency management
+## Notes on Dependency Management
 
 The recommended way is to use [vcpkg](https://vcpkg.io/).
 See `INSTALL.md` for more details.
-On windows, one may run
+On Windows, one may run
 
 ```powershell
 git clone https://github.com/microsoft/vcpkg.git

--- a/MAINTAINER-LICENSE-GUIDE.md
+++ b/MAINTAINER-LICENSE-GUIDE.md
@@ -50,7 +50,7 @@ works correctly.
 
 The default is `${CMAKE_INSTALL_FULL_DATADIR}/doc/asymptote/licenses`.
 
-### Common distro paths
+### Common Distro Paths
 | Distribution | Typical path |
 |---|---|
 | Fedora / RHEL | `/usr/share/licenses/asymptote` |
@@ -86,18 +86,18 @@ _Note: wyhash/ is public domain, but retain the original header comment creditin
 
 ## Distributing Asymptote
 
-### Source distributions
+### Source Distributions
 Include all components unchanged with their license files. No additional
 action is required beyond what the repository already contains.
 
-### Binary distributions
+### Binary Distributions
 Include the `licenses/` folder alongside the binary, plus
 `LICENSES-THIRD-PARTY.md`. The `licenses/` folder contains `LICENSE`,
 `LICENSE.LESSER`, and all third-party license files. The `asy --licenses=full`
 command reads from this folder and is suitable for auditing and convenience
 but is not a substitute for distributing the actual `licenses/` folder.
 
-### OS package managers (apt, yum, brew, macports)
+### OS Package Managers (apt, yum, brew, macports)
 - SPDX license metadata: `LGPL-3.0-or-later AND Unlicense AND MIT AND Boost-1.0 AND BSD-3-Clause AND GPL-2.0-only`
 - Place license files using the distro-standard location (see
   "Configuring the License Installation Directory" above).


### PR DESCRIPTION
## Description
This PR fixes section heading Title Case capitalization in `MAINTAINER-LICENSE-GUIDE.md`.

## Details
Updated headers (`### Common distro paths`, `### Source distributions`, `### Binary distributions`, and `### OS package managers`) to match Title Case conventions.