### PR TITLE
docs: fix Windows naming and code snippet formatting in README

### DIFF
--- a/INSTALL-WIN.md
+++ b/INSTALL-WIN.md
@@ -5,7 +5,7 @@
 ### Required Dependencies
 Ensure the following is installed:
 - Visual Studio 2022+ or Visual Studio 2022+ build tools.
-  - Both can be found at [here](https://visualstudio.microsoft.com/downloads/).
+  - Both can be found [here](https://visualstudio.microsoft.com/downloads/).
 - CMake
   - (Recommended way) Visual Studio/Visual Studio Build Tools provides bundled CMake as a selectable component
   - Otherwise, CMake can be found [here](https://cmake.org/)
@@ -48,11 +48,11 @@ This script automatically checks that you have vcpkg, and if not, clones and boo
 Additionally, this script automatically locates your Visual Studio installation and
 establishes all required environment variables.
 
-## Notes on Dependency management
+## Notes on Dependency Management
 
 The recommended way is to use [vcpkg](https://vcpkg.io/).
 See `INSTALL.md` for more details.
-On windows, one may run
+On Windows, one may run
 
 ```powershell
 git clone https://github.com/microsoft/vcpkg.git

--- a/MAINTAINER-LICENSE-GUIDE.md
+++ b/MAINTAINER-LICENSE-GUIDE.md
@@ -50,7 +50,7 @@ works correctly.
 
 The default is `${CMAKE_INSTALL_FULL_DATADIR}/doc/asymptote/licenses`.
 
-### Common distro paths
+### Common Distro Paths
 | Distribution | Typical path |
 |---|---|
 | Fedora / RHEL | `/usr/share/licenses/asymptote` |
@@ -86,18 +86,18 @@ _Note: wyhash/ is public domain, but retain the original header comment creditin
 
 ## Distributing Asymptote
 
-### Source distributions
+### Source Distributions
 Include all components unchanged with their license files. No additional
 action is required beyond what the repository already contains.
 
-### Binary distributions
+### Binary Distributions
 Include the `licenses/` folder alongside the binary, plus
 `LICENSES-THIRD-PARTY.md`. The `licenses/` folder contains `LICENSE`,
 `LICENSE.LESSER`, and all third-party license files. The `asy --licenses=full`
 command reads from this folder and is suitable for auditing and convenience
 but is not a substitute for distributing the actual `licenses/` folder.
 
-### OS package managers (apt, yum, brew, macports)
+### OS Package Managers (apt, yum, brew, macports)
 - SPDX license metadata: `LGPL-3.0-or-later AND Unlicense AND MIT AND Boost-1.0 AND BSD-3-Clause AND GPL-2.0-only`
 - Place license files using the distro-standard location (see
   "Configuring the License Installation Directory" above).

--- a/README
+++ b/README
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ========================================================================
 
-Note that the MSWindows executable of Asymptote available on
+Note that the Windows executable of Asymptote available on
 https://asymptote.sourceforge.io and https://ctan.org
 can only be released under the GNU General Public License (GPL) as it
 ships with the GNU Scientific Library, GNU Readline library,
@@ -93,5 +93,5 @@ THIRD-PARTY COMPONENTS
 Asymptote includes several third-party libraries (span-lite, wyhash,
 Boehm GC, LspCpp, libatomic_ops, GLEW, TinyEXR), each with their own
 license terms.  See LICENSES-THIRD-PARTY.md for the component list, or
-run asy --licenses=full to print the full license texts from the installed
-licenses/ directory.
+run `asy --licenses=full` to print the full license texts from the installed
+`licenses/` directory.


### PR DESCRIPTION
## Description
This PR fixes OS name formatting and adds inline code formatting in `README`.

## Details
1. Standardized Windows platform name (`MSWindows` $\to$ `Windows`).
2. Added backticks for command and directory references (`asy --licenses=full` and `licenses/`).