### PR TITLE
Do not interpolate a surface as periodic unless it really repeats

### DIFF
--- a/base/graph3.asy
+++ b/base/graph3.asy
@@ -1615,7 +1615,7 @@ path3[] segment(triple[] v, bool[] cond, interpolate3 join=operator --)
 // 2, while data that doubles back reaches 3.2 at worst.  Cross sections
 // severely peaked at the seam itself can reach 4.4 and will fall back to
 // notaknot, which costs little on such data.
-real periodicSlopeTolerance=3;
+private real periodicSlopeTolerance=3;
 
 private bool slopesAgreeAtSeam(real[] a)
 {

--- a/base/graph3.asy
+++ b/base/graph3.asy
@@ -1601,6 +1601,34 @@ path3[] segment(triple[] v, bool[] cond, interpolate3 join=operator --)
                   segment.length);
 }
 
+// Returning to its initial value is not enough to make a sample periodic:
+// r*cos(theta) over a half turn closes up in value but arrives with the
+// opposite slope, and imposing s'(a)=s'(b) on it flattens both ends.  Compare
+// the secant slopes on either side of the seam of the periodic extension of a
+// against the largest change in secant slope within a itself.  Only slopes
+// enter, so a constant offset between the ends cancels and the same test
+// serves a sample that repeats outright and one that repeats after a
+// translation.  Genuinely periodic samples bend no more sharply at the seam
+// than they do anywhere else; a sample that merely retraces itself bends far
+// more.  Measured over 5 to 80 intervals, ordinary closed cross sections --
+// circles, ellipses, epitrochoids, limacons, roses, superellipses -- peak at
+// 2, while data that doubles back reaches 3.2 at worst.  Cross sections
+// severely peaked at the seam itself can reach 4.4 and will fall back to
+// notaknot, which costs little on such data.
+real periodicSlopeTolerance=3;
+
+private bool slopesAgreeAtSeam(real[] a)
+{
+  int n=a.length;
+  if(n < 3) return true;
+  // Second difference of the periodic extension at the seam.
+  real seam=abs((a[1]-a[0])-(a[n-1]-a[n-2]));
+  if(seam <= sqrtEpsilon*max(abs(a))) return true;
+  // Largest second difference within a itself.
+  real interior=max(abs(a[2:n]-2*a[1:n-1]+a[0:n-2]));
+  return seam <= periodicSlopeTolerance*interior;
+}
+
 bool uperiodic(real[][] a) {
   int n=a.length;
   if(n == 0) return false;
@@ -1626,6 +1654,52 @@ bool vperiodic(real[][] a) {
     if(abs(ai[0]-ai[m]) > epsilon) return false;
   }
   return true;
+}
+
+// True if the sample repeats along its first index after a constant
+// translation: f[n-1][j] = f[0][j]+D for a vector D independent of j, and the
+// two ends of each column meet with the same slope, so that one period
+// continues into the next without a kink.  D=0 is an ordinary closed surface;
+// D nonzero is a screw motion, one turn of a helicoid.
+//
+// The offset is a property of the surface rather than of the coordinate
+// frame -- rotating the surface rotates D but leaves it constant -- so, unlike
+// asking whether each coordinate separately returns to its initial value, this
+// recognizes a helicoid whatever its axis.  All three components are tested
+// together for the same reason: a parameterization repeats as a whole or not
+// at all, and testing them one at a time lets a single component that merely
+// returns to its initial value -- x=r*cos(theta) at both ends of a half turn,
+// say -- be interpolated periodically while its partners are not.
+private bool translated(real[][] fx, real[][] fy, real[][] fz)
+{
+  int n=fx.length;
+  if(n == 0 || fx[0].length == 0) return false;
+
+  real epsilon=sqrtEpsilon*max(norm(fx),norm(fy),norm(fz));
+
+  // The offset, as three arrays indexed by j; each entry must agree with the
+  // first.  Comparing the squared distances keeps the test independent of the
+  // coordinate frame, as the offset itself is.
+  real[] dx=fx[n-1]-fx[0];
+  real[] dy=fy[n-1]-fy[0];
+  real[] dz=fz[n-1]-fz[0];
+  real[] ex=dx-dx[0], ey=dy-dy[0], ez=dz-dz[0];
+  if(max(ex^2+ey^2+ez^2) > epsilon^2) return false;
+
+  for(real[][] f : new real[][][] {transpose(fx),transpose(fy),transpose(fz)})
+    for(real[] column : f)
+      if(!slopesAgreeAtSeam(column)) return false;
+  return true;
+}
+
+// True if a parametric surface repeats in u (respectively v) after a constant
+// translation, so that periodicOffset end conditions are appropriate there.
+bool uPeriodicOffset(real[][] fx, real[][] fy, real[][] fz) {
+  return translated(fx,fy,fz);
+}
+
+bool vPeriodicOffset(real[][] fx, real[][] fy, real[][] fz) {
+  return translated(transpose(fx),transpose(fy),transpose(fz));
 }
 
 bool uperiodic(triple[][] a) {
@@ -2062,15 +2136,13 @@ surface surface(picture pic=currentpicture, triple f(pair z),
   }
 
   if(usplinetype.length == 0) {
-    usplinetype=new splinetype[] {uperiodic(fx) ? periodic : notaknot,
-                                  uperiodic(fy) ? periodic : notaknot,
-                                  uperiodic(fz) ? periodic : notaknot};
+    splinetype u=uPeriodicOffset(fx,fy,fz) ? periodicOffset : notaknot;
+    usplinetype=new splinetype[] {u,u,u};
   } else if(usplinetype.length != 3) abort("usplinetype must have length 3");
 
   if(vsplinetype.length == 0) {
-    vsplinetype=new splinetype[] {vperiodic(fx) ? periodic : notaknot,
-                                  vperiodic(fy) ? periodic : notaknot,
-                                  vperiodic(fz) ? periodic : notaknot};
+    splinetype v=vPeriodicOffset(fx,fy,fz) ? periodicOffset : notaknot;
+    vsplinetype=new splinetype[] {v,v,v};
   } else if(vsplinetype.length != 3) abort("vsplinetype must have length 3");
 
   real[][][] sx=bispline(fx,ipt,jpt,usplinetype[0],vsplinetype[0],active);
@@ -2105,11 +2177,20 @@ surface surface(picture pic=currentpicture, triple f(pair z),
     s.s[k]=patch(Q);
   }
 
-  if(usplinetype[0] == periodic && usplinetype[1] == periodic &&
-     usplinetype[1] == periodic) s.ucyclic(true);
+  // A cyclic u parameter should have splinetype either periodic or
+  // periodicOffset. The periodicOffset splinetype also accepts a screw
+  // motion; to rule this out, we test uperiodic. The story for v is similar.
+  bool joinsSmoothly(splinetype t) {
+    return t == periodic || t == periodicOffset;
+  }
 
-  if(vsplinetype[0] == periodic && vsplinetype[1] == periodic &&
-     vsplinetype[1] == periodic) s.vcyclic(true);
+  if(joinsSmoothly(usplinetype[0]) && joinsSmoothly(usplinetype[1]) &&
+     joinsSmoothly(usplinetype[2]) &&
+     uperiodic(fx) && uperiodic(fy) && uperiodic(fz)) s.ucyclic(true);
+
+  if(joinsSmoothly(vsplinetype[0]) && joinsSmoothly(vsplinetype[1]) &&
+     joinsSmoothly(vsplinetype[2]) &&
+     vperiodic(fx) && vperiodic(fy) && vperiodic(fz)) s.vcyclic(true);
 
   return s;
 }

--- a/base/graph_splinetype.asy
+++ b/base/graph_splinetype.asy
@@ -1,5 +1,7 @@
 private import math;
 
+// Given knots x and values y, return the derivatives dy/dx at the knots, one
+// per knot.  Callers convert these to Bezier control points.
 typedef real[] splinetype(real[], real[]);
 
 restricted real[] Spline(real[] x, real[] y);
@@ -109,6 +111,25 @@ real[] periodic(real[] x, real[] y)
     d=new real[] {0,0};
   } else abort(morepoints);
   return d;
+}
+
+// Cubic spline interpolation with the periodic conditions s'(a)=s'(b),
+// s''(a)=s''(b), but without assuming f(a)=f(b): the sample may repeat after a
+// constant offset, as along one turn of a helix.  Subtract the linear drift
+// carrying y[0] to y[n-1], interpolate the remainder periodically, then add
+// the drift's slope back to every derivative.  A cubic spline plus a linear
+// function is again a cubic spline, so this is exact; with a zero offset it
+// reduces to periodic.
+real[] periodicOffset(real[] x, real[] y)
+{
+  int n=x.length;
+  checklengths(n,y.length);
+  checkincreasing(x);
+  if(n < 2) abort(morepoints);
+  real slope=(y[n-1]-y[0])/(x[n-1]-x[0]);
+  real[] z=y-slope*(x-x[0]);
+  z[n-1]=z[0];
+  return periodic(x,z)+slope;
 }
 
 // Standard cubic spline interpolation with the natural condition
@@ -229,7 +250,7 @@ real[] monotonic(real[] x, real[] y)
     else if((sgn(del[0]) != sgn(del[1])) && (abs(d[0]) > abs(3*del[0])))
       d[0]=3*del[0];
 
-    d[n-1]=((2*h[n-2]+h[n-3])*del[n-2]-h[n-2]*del[n-2])/(h[n-2]+h[n-3]);
+    d[n-1]=((2*h[n-2]+h[n-3])*del[n-2]-h[n-2]*del[n-3])/(h[n-2]+h[n-3]);
     if(sgn(d[n-1]) != sgn(del[n-2])) {d[n-1]=0;}
     else if((sgn(del[n-2]) != sgn(del[n-3])) &&
             (abs(d[n-1]) > abs(3*del[n-2])))

--- a/doc/asymptote.texi
+++ b/doc/asymptote.texi
@@ -8376,9 +8376,9 @@ the abbreviation @code{Spline} is also accepted);
 @item @code{linear} (linear interpolation),
 @item @code{Hermite} (standard cubic spline interpolation using boundary
 condition @code{notaknot}, @code{natural},  @code{periodic},
-@code{periodicOffset} (like @code{periodic}, but for data that repeats
-after a constant offset, as in @math{y=x+\sin x}),
-@code{clamped(real slopea, real slopeb)}), or @code{monotonic}.
+@code{periodicOffset}, @footnote{like @code{periodic} but for data that repeats
+after a constant offset, as in @math{y=x+\sin x}.}
+@code{clamped(real slopea, real slopeb)}, or @code{monotonic}).
 The abbreviation @code{Hermite} is equivalent to
 @code{Hermite(notaknot)} for nonperiodic data and
 @code{Hermite(periodic)} for periodic data).

--- a/doc/asymptote.texi
+++ b/doc/asymptote.texi
@@ -8369,12 +8369,15 @@ the abbreviation @code{Spline} is also accepted);
 @cindex @code{notaknot}
 @cindex @code{natural}
 @cindex @code{periodic}
+@cindex @code{periodicOffset}
 @cindex @code{clamped}
 @cindex @code{monotonic}
 @cindex @code{Hermite(splinetype splinetype}
 @item @code{linear} (linear interpolation),
 @item @code{Hermite} (standard cubic spline interpolation using boundary
 condition @code{notaknot}, @code{natural},  @code{periodic},
+@code{periodicOffset} (like @code{periodic}, but for data that repeats
+after a constant offset, as in @math{y=x+\sin x}),
 @code{clamped(real slopea, real slopeb)}), or @code{monotonic}.
 The abbreviation @code{Hermite} is equivalent to
 @code{Hermite(notaknot)} for nonperiodic data and


### PR DESCRIPTION
The parametric surface constructor tested each coordinate separately, so a coordinate that merely returns to its initial value -- x=r*cos(theta) over a half turn -- was given periodic end conditions, flattening the surface at the seam.  Require instead that the whole parameterization repeat after a constant vector offset with matching end slopes.  The surfaces the old test had served by accident, screw motions whose two ends differ by a translation, are interpolated with the new periodicOffset splinetype; being rotationally invariant, the test also recognizes a tilted helicoid.

Also fix monotonic's right-end derivative, which collapsed to the last secant slope.