### PR TITLE
Share one executable-path implementation via locate.h.

### DIFF
--- a/locate.cc
+++ b/locate.cc
@@ -266,18 +266,6 @@ string resolveSysdir(string const& compiledInSysdir) noexcept
     }
     return compiledInSysdir;
   } catch (...) {
-    // asy_malloc() throws std::bad_alloc rather than returning null, so any
-    // allocation above can land here. Treat it as "no candidate matched" and
-    // use the compiled-in path, which is what an installed binary resolves to
-    // anyway; relocatedSysdir is left false, so a MSWindows registry entry
-    // still applies.
-    //
-    // Deliberately not "": that value marks a TeXLive build and would divert
-    // the search to kpsewhich, silently mis-configuring a binary that is not
-    // one. Copying compiledInSysdir can itself allocate, but if that fails the
-    // process is out of memory before main() and terminating is the honest
-    // outcome -- and the MSWindows sysdir is short enough to fit a string's
-    // internal buffer, so it does not allocate there at all.
     return compiledInSysdir;
   }
 }

--- a/locate.cc
+++ b/locate.cc
@@ -76,7 +76,9 @@ static string canonicalPath(std::filesystem::path const& path)
 #endif
 
 // Absolute path of the running executable, or "" if it cannot be determined.
-static string getExecutablePath()
+// Declared in locate.h: rendererloader.cc and vkrender.cc resolve co-installed
+// files (renderer shared libraries, ICD manifests) against it too.
+string executablePath()
 {
 #if defined(_WIN32)
   // GetModuleFileNameW truncates rather than failing when the path does not
@@ -119,6 +121,56 @@ static string getExecutablePath()
 #endif
 }
 
+// The directory part of path, or nullopt if it has none. An optional rather
+// than a string because a path directly under a POSIX root has an empty
+// directory part ("/bin" -> ""), which "" as a return value would conflate with
+// having no directory part at all ("asy" -> nullopt).
+//
+// A backslash is an ordinary character in a POSIX filename, so scanning for the
+// last separator is exactly right there. On MSWindows it is not, which is why
+// that branch defers to std::filesystem::path:
+//
+//  - "C:\asy.exe" splits to "C:", which is drive-*relative*: appending to it
+//    resolves against the current directory of drive C:, not its root.
+//    parent_path() yields "C:\" instead.
+//  - 0x5C is a legal trail byte in Shift-JIS, Big5 and GBK, so a scan of the
+//    narrow (process code page) form can split in the middle of a character.
+//    path parses the wide form, where it cannot.
+//  - a UNC path keeps its root name: "\\server\share" rather than "\\server".
+//
+// A root parent is the one result that carries a trailing separator ("C:\"), so
+// a caller appending "/base" to it gets "C:\/base"; Win32 collapses the doubled
+// separator, and no non-root parent is affected.
+static optional<string> parentDir(string const& path)
+{
+#if defined(_WIN32)
+  std::filesystem::path const full(path.c_str());
+  if (!full.has_parent_path())
+    return nullopt;
+  // A parent that exists is never empty on MSWindows -- it is at minimum a root
+  // ("C:\", "\") or a drive ("C:") -- so an empty result here means narrowPath()
+  // failed. Report no parent rather than "", which the caller would otherwise
+  // append to and get a path relative to the current drive.
+  string const dir= narrowPath(full.parent_path());
+  if (dir.empty())
+    return nullopt;
+  return dir;
+#else
+  size_t slash= path.find_last_of('/');
+  if (slash == string::npos)
+    return nullopt;
+  return path.substr(0, slash);
+#endif
+}
+
+// The directory containing the running executable, or "" if it cannot be
+// determined. An executablePath() that is empty, or that has no separator at
+// all, both yield "" here.
+string executableDir()
+{
+  return parentDir(executablePath()).value_or("");
+}
+
 // A directory is only accepted as a base directory if it contains this file.
 // Mere existence of the directory proves nothing: the compiled-in path may
 // belong to an unrelated (or half-removed) Asymptote installation.
@@ -156,34 +208,33 @@ string resolveSysdir(string const& compiledInSysdir)
   if (compiledInSysdir.empty())
     return compiledInSysdir;
 
-  string exe= getExecutablePath();
-  if (!exe.empty()) {
-    size_t slash= exe.find_last_of("/\\");
-    if (slash != string::npos) {
-      string bindir= exe.substr(0, slash);
-      // Build tree: base/ sits next to the executable.
-      string buildBase= bindir + "/base";
-      if (isBaseDir(buildBase)) {
-        relocatedSysdir= true;
-        return buildBase;
-      }
-#ifdef IS_RELOCATABLE
-      // Install tree: <prefix>/bin/asy with data in <prefix>/share/asymptote.
-      size_t slash2= bindir.find_last_of("/\\");
-      if (slash2 != string::npos) {
-        string shareBase= bindir.substr(0, slash2) + "/share/asymptote";
-        if (isBaseDir(shareBase)) {
-          relocatedSysdir= true;
-          return shareBase;
-        }
-      }
-      // Flat layout (the MSWindows installer): base files beside asy.exe.
-      if (isBaseDir(bindir)) {
-        relocatedSysdir= true;
-        return bindir;
-      }
-#endif
+  // parentDir() rather than executableDir(), so that an executable sitting
+  // directly in the filesystem root still gets its candidates tried.
+  optional<string> const exeDir= parentDir(executablePath());
+  if (exeDir) {
+    string const& bindir= *exeDir;
+    // Build tree: base/ sits next to the executable.
+    string buildBase= bindir + "/base";
+    if (isBaseDir(buildBase)) {
+      relocatedSysdir= true;
+      return buildBase;
     }
+#ifdef IS_RELOCATABLE
+    // Install tree: <prefix>/bin/asy with data in <prefix>/share/asymptote.
+    optional<string> const prefix= parentDir(bindir);
+    if (prefix) {
+      string shareBase= *prefix + "/share/asymptote";
+      if (isBaseDir(shareBase)) {
+        relocatedSysdir= true;
+        return shareBase;
+      }
+    }
+    // Flat layout (the MSWindows installer): base files beside asy.exe.
+    if (isBaseDir(bindir)) {
+      relocatedSysdir= true;
+      return bindir;
+    }
+#endif
   }
   return compiledInSysdir;
 }

--- a/locate.cc
+++ b/locate.cc
@@ -8,6 +8,7 @@
 #if defined(_WIN32)
 #  include <filesystem>
 #  include <system_error>
+#  include <vector>
 #  include <Windows.h>
 #else
 #  include <unistd.h>
@@ -44,9 +45,10 @@ bool relocatedSysdir= false;
 // A path containing characters outside that code page is therefore not
 // representable here, and path::string() substitutes for them silently.
 
-// Returns "" rather than letting an exception escape: resolveSysdir() runs as a
-// static initializer, where an escaping exception calls terminate() before
-// main() rather than being caught anywhere.
+// Returns "" rather than letting an exception escape. resolveSysdir() guards
+// its whole body for the static-initializer case, but this is also reached at
+// runtime through executableDir(), and "" is the not-representable answer both
+// paths already handle.
 static string narrowPath(std::filesystem::path const& path)
 {
   try {
@@ -82,21 +84,37 @@ string executablePath()
 {
 #if defined(_WIN32)
   // GetModuleFileNameW truncates rather than failing when the path does not
-  // fit, so allocate for the longest path Windows documents (32767 characters)
-  // rather than the MAX_PATH (260) that long-path support can exceed. That
-  // limit counts characters, so the wide form is what it bounds: the same
+  // fit, reporting the buffer size when it does. MAX_PATH (260) covers every
+  // path not using long-path support, so try the stack first and fall back to
+  // the heap only for the rare path that needs it. The fallback is sized for
+  // the longest path Windows can represent (32767 characters), so one retry
+  // either fits or the path is unobtainable -- there is nothing to loop over.
+  // That limit counts characters, so the wide form is what it bounds: the same
   // number of bytes can fall short of it under a double-byte code page.
-  DWORD const size= 32768;
-  mem::vector<wchar_t> buf(size);
-  DWORD len= GetModuleFileNameW(nullptr, buf.data(), size);
-  if (len == 0 || len == size)// 0: failed; size: truncated
+  //
+  // std::vector rather than mem::vector: the buffer never escapes and holds no
+  // collectable pointers, so there is no reason to place it under the garbage
+  // collector -- which would scan it for pointers.
+  DWORD const maxSize= 32768;
+  wchar_t stackBuf[MAX_PATH];
+  std::vector<wchar_t> heapBuf;// stays empty unless the stack buffer is short
+  wchar_t const* data= stackBuf;
+  DWORD len= GetModuleFileNameW(nullptr, stackBuf, MAX_PATH);
+  if (len == 0)// failed
     return "";
+  if (len == MAX_PATH) {// truncated; retry at the documented maximum
+    heapBuf.resize(maxSize);
+    len= GetModuleFileNameW(nullptr, heapBuf.data(), maxSize);
+    if (len == 0 || len == maxSize)
+      return "";
+    data= heapBuf.data();
+  }
   // GetModuleFileNameW does not resolve symlinks: launched through a link on
   // PATH it reports the link, whose directory holds no base/. Resolve it so
   // that such a link yields the real install prefix, as on the other two
   // platforms. Falling back to the unresolved path on failure mirrors what the
   // macOS branch does when realpath() fails.
-  std::filesystem::path const exe(buf.data(), buf.data() + len);
+  std::filesystem::path const exe(data, data + len);
   string resolved= canonicalPath(exe);
   return resolved.empty() ? narrowPath(exe) : resolved;
 #elif defined(__APPLE__)
@@ -199,44 +217,69 @@ static bool isBaseDir(string const& dir)
 // from a package, so it needs no opt-in. The install-tree and flat candidates
 // are gated behind IS_RELOCATABLE.
 //
-string resolveSysdir(string const& compiledInSysdir)
+// noexcept because this runs as a static initializer (settings.cc), where an
+// escaping exception calls terminate() before main() rather than being caught
+// anywhere. Marking it costs nothing there -- terminate() is what an escaping
+// exception would produce either way -- and states the contract in a form the
+// compiler checks rather than one a comment can drift away from. The body is
+// guarded as a whole rather than at each allocating step: every candidate is
+// built from strings and std::filesystem paths, so the throwing operations are
+// too many to enumerate reliably, and all of them mean the same thing here.
+//
+string resolveSysdir(string const& compiledInSysdir) noexcept
 {
-  // An empty compiled-in sysdir marks a TeXLive build, whose data directory is
-  // defined only by kpathsea. It must always defer to kpsewhich, so never
-  // relocate it relative to the executable -- even when a base/ sits beside the
-  // binary (e.g. when run in place from its build tree).
-  if (compiledInSysdir.empty())
-    return compiledInSysdir;
+  try {
+    // An empty compiled-in sysdir marks a TeXLive build, whose data directory
+    // is defined only by kpathsea. It must always defer to kpsewhich, so never
+    // relocate it relative to the executable -- even when a base/ sits beside
+    // the binary (e.g. when run in place from its build tree).
+    if (compiledInSysdir.empty())
+      return compiledInSysdir;
 
-  // parentDir() rather than executableDir(), so that an executable sitting
-  // directly in the filesystem root still gets its candidates tried.
-  optional<string> const exeDir= parentDir(executablePath());
-  if (exeDir) {
-    string const& bindir= *exeDir;
-    // Build tree: base/ sits next to the executable.
-    string buildBase= bindir + "/base";
-    if (isBaseDir(buildBase)) {
-      relocatedSysdir= true;
-      return buildBase;
-    }
-#ifdef IS_RELOCATABLE
-    // Install tree: <prefix>/bin/asy with data in <prefix>/share/asymptote.
-    optional<string> const prefix= parentDir(bindir);
-    if (prefix) {
-      string shareBase= *prefix + "/share/asymptote";
-      if (isBaseDir(shareBase)) {
+    // parentDir() rather than executableDir(), so that an executable sitting
+    // directly in the filesystem root still gets its candidates tried.
+    optional<string> const exeDir= parentDir(executablePath());
+    if (exeDir) {
+      string const& bindir= *exeDir;
+      // Build tree: base/ sits next to the executable.
+      string buildBase= bindir + "/base";
+      if (isBaseDir(buildBase)) {
         relocatedSysdir= true;
-        return shareBase;
+        return buildBase;
       }
-    }
-    // Flat layout (the MSWindows installer): base files beside asy.exe.
-    if (isBaseDir(bindir)) {
-      relocatedSysdir= true;
-      return bindir;
-    }
+#ifdef IS_RELOCATABLE
+      // Install tree: <prefix>/bin/asy with data in <prefix>/share/asymptote.
+      optional<string> const prefix= parentDir(bindir);
+      if (prefix) {
+        string shareBase= *prefix + "/share/asymptote";
+        if (isBaseDir(shareBase)) {
+          relocatedSysdir= true;
+          return shareBase;
+        }
+      }
+      // Flat layout (the MSWindows installer): base files beside asy.exe.
+      if (isBaseDir(bindir)) {
+        relocatedSysdir= true;
+        return bindir;
+      }
 #endif
+    }
+    return compiledInSysdir;
+  } catch (...) {
+    // asy_malloc() throws std::bad_alloc rather than returning null, so any
+    // allocation above can land here. Treat it as "no candidate matched" and
+    // use the compiled-in path, which is what an installed binary resolves to
+    // anyway; relocatedSysdir is left false, so a MSWindows registry entry
+    // still applies.
+    //
+    // Deliberately not "": that value marks a TeXLive build and would divert
+    // the search to kpsewhich, silently mis-configuring a binary that is not
+    // one. Copying compiledInSysdir can itself allocate, but if that fails the
+    // process is out of memory before main() and terminating is the honest
+    // outcome -- and the MSWindows sysdir is short enough to fit a string's
+    // internal buffer, so it does not allocate there at all.
+    return compiledInSysdir;
   }
-  return compiledInSysdir;
 }
 
 namespace fs

--- a/locate.h
+++ b/locate.h
@@ -37,8 +37,9 @@ string executableDir();
 // base/ rather than that of a separately installed Asymptote. Callers must pass
 // ASYMPTOTE_SYSDIR in: under CMake it differs between asy and asy-ctan, and
 // settings.cc is the only source file compiled separately per executable.
-// See locate.cc.
-string resolveSysdir(string const& compiledInSysdir);
+// noexcept: it runs as a static initializer, so it reports every failure by
+// falling back to compiledInSysdir rather than by throwing. See locate.cc.
+string resolveSysdir(string const& compiledInSysdir) noexcept;
 
 // True if initSysdir() resolved systemDir relative to the running executable.
 // Used to keep an installed Asymptote's configuration (the MSWindows registry

--- a/locate.h
+++ b/locate.h
@@ -16,6 +16,21 @@ namespace settings {
 typedef mem::list<string> file_list_t;
 extern file_list_t searchPath;
 
+// Absolute path of the running executable, or "" if it cannot be determined.
+// Symlinks are resolved, so a binary reached through a link on PATH (or a
+// symlinked bin directory, as Homebrew and MacPorts create) still yields the
+// real install prefix. On MSWindows the result is narrowed to the process code
+// page, which is the encoding the ...A file APIs used elsewhere expect.
+string executablePath();
+
+// The directory containing the running executable, without a trailing
+// separator (except for a root directory, where the separator is part of it:
+// "C:\"), or "" if it cannot be determined. Callers that need to resolve a
+// co-installed file (base/, a renderer shared library, an ICD manifest) should
+// use this rather than rolling their own: the search path is CWD-dependent and
+// can pick up a stale system-wide installation.
+string executableDir();
+
 // Determine the system base directory (used to initialize settings::systemDir).
 // Candidates relative to the running executable are preferred over the
 // compiled-in ASYMPTOTE_SYSDIR, so that a binary run in place uses its own

--- a/rendererloader.cc
+++ b/rendererloader.cc
@@ -64,17 +64,12 @@ bool vulkan = false;
 #include <pthread.h>
 #include <string>
 
-#ifndef _WIN32
-#  include <unistd.h>
-#  ifdef __APPLE__
-#    include <limits.h>
-#    include <stdlib.h>
-#    include <mach-o/dyld.h>
-#  endif
+#ifdef __APPLE__
+#  include <stdlib.h>    // for realpath(), setenv() in the llvmpipe fallback
 #endif
 
 #include "settings.h"    // for settings::verbose
-#include "locate.h"       // for settings::locateFile
+#include "locate.h"      // for settings::locateFile, settings::executableDir
 
 namespace camp {
 
@@ -105,45 +100,13 @@ static void *glLibHandle = nullptr;
  * Returns a valid handle on success, or nullptr on failure.
  */
 #ifndef _WIN32
-// Directory containing the running executable, or "" if it cannot be
-// determined. Used to resolve the co-installed renderer shared libraries
-// relative to the executable rather than via the CWD-dependent Asymptote search
-// path (which can pick up a stale system-installed lib when asy is run from
-// outside the build directory). Mirrors settings::getExecutablePath() in
-// locate.cc.
-static string executableDir()
-{
-    char buf[4096];
-    const char *exePath = buf;
-#if defined(__APPLE__)
-    uint32_t size = (uint32_t)sizeof(buf);
-    if (_NSGetExecutablePath(buf, &size) != 0)
-        return "";
-    // Resolve symlinks so a symlinked bin directory (Homebrew, MacPorts) yields
-    // the real install prefix; fall back to the unresolved path on failure.
-    char resolved[PATH_MAX];
-    if (realpath(buf, resolved) != nullptr)
-        exePath = resolved;
-#else
-    ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
-    if (len <= 0)
-        return "";
-    buf[len] = '\0';
-#endif
-    string exe(exePath);
-    size_t slash = exe.find_last_of('/');
-    if (slash == string::npos)
-        return "";
-    return exe.substr(0, slash);
-}
-
 // Resolve a renderer shared library path. Prefer a copy that sits next to the
 // executable (the build tree's lib); otherwise fall back to the Asymptote
 // search path. Relying on locateFile() alone is CWD-dependent and can pick up a
 // stale system-installed lib when asy is run from outside the build directory.
 static string resolveRendererLib(const char *libName)
 {
-    string dir = executableDir();
+    string dir = settings::executableDir();
     if (!dir.empty()) {
         string candidate = dir + "/" + libName;
         if (settings::fs::exists(candidate))
@@ -469,26 +432,15 @@ void createRenderer()
         // VK_ICD_FILENAMES so the Vulkan loader picks it up on the next
         // instance creation.
 
-        // 1) Determine the directory of our own executable.
-        std::string exeDir;
-        {
-            char buf[MAX_PATH];
-            DWORD len = GetModuleFileNameA(nullptr, buf, MAX_PATH);
-            if (len > 0 && len < MAX_PATH) {
-                std::string exePath(buf);
-                size_t slash = exePath.find_last_of("\\/");
-                if (slash != std::string::npos)
-                    exeDir = exePath.substr(0, slash + 1);
-            }
-        }
+        // 1) Determine the directory of our own executable. Both files below
+        //    fall back to a bare name -- resolved against the current
+        //    directory, and for the DLL against the standard search order --
+        //    if it cannot be determined.
+        std::string const exeDir = mem::stdString(settings::executableDir());
 
         // 2) Write lvp_icd.json next to the executable.
-        std::string icdName = "lvp_icd.json";
-        std::string icdPath;
-        if (!exeDir.empty())
-            icdPath = exeDir + icdName;
-        else
-            icdPath = icdName;
+        std::string icdPath =
+            exeDir.empty() ? "lvp_icd.json" : exeDir + "\\lvp_icd.json";
 
         {
             std::ofstream ofs(icdPath.c_str(), std::ios::trunc);
@@ -510,11 +462,8 @@ void createRenderer()
         _putenv_s("VK_ICD_FILENAMES", icdPath.c_str());
 
         // 4) Load vulkan_lvp.dll (the Lavapipe driver).
-        std::string lvpDllPath;
-        if (!exeDir.empty())
-            lvpDllPath = exeDir + "vulkan_lvp.dll";
-        else
-            lvpDllPath = "vulkan_lvp.dll";
+        std::string const lvpDllPath =
+            exeDir.empty() ? "vulkan_lvp.dll" : exeDir + "\\vulkan_lvp.dll";
 
         lvpLibHandle = LoadLibraryA(lvpDllPath.c_str());
         if (lvpLibHandle) {

--- a/vkrender.cc
+++ b/vkrender.cc
@@ -37,9 +37,10 @@
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
 #elif defined(__APPLE__)
-#include <mach-o/dyld.h>
 #include <sys/stat.h>
 #endif
+
+#include "locate.h"  // for settings::executableDir
 
 using settings::getSetting;
 using settings::Setting;
@@ -433,21 +434,13 @@ void AsyVkRender::initVulkan()
 #ifdef __APPLE__
   // Point the Vulkan loader to the bundled MoltenVK ICD if available
   {
-    char exePath[PATH_MAX];
-    uint32_t size = sizeof(exePath);
-    if (_NSGetExecutablePath(exePath, &size) == 0) {
-      char realPath[PATH_MAX];
-      if (realpath(exePath, realPath)) {
-        std::string exeDir(realPath);
-        size_t lastSlash = exeDir.rfind('/');
-        if (lastSlash != std::string::npos)
-          exeDir = exeDir.substr(0, lastSlash);
-        std::string icdPath = exeDir + "/lib/MoltenVK_icd.json";
-        struct stat st;
-        if (stat(icdPath.c_str(), &st) == 0 && S_ISREG(st.st_mode)) {
-          setenv("VK_ICD_FILENAMES", icdPath.c_str(), 0);
-          setenv("VK_DRIVER_FILES", icdPath.c_str(), 0);
-        }
+    std::string const exeDir = mem::stdString(settings::executableDir());
+    if (!exeDir.empty()) {
+      std::string icdPath = exeDir + "/lib/MoltenVK_icd.json";
+      struct stat st;
+      if (stat(icdPath.c_str(), &st) == 0 && S_ISREG(st.st_mode)) {
+        setenv("VK_ICD_FILENAMES", icdPath.c_str(), 0);
+        setenv("VK_DRIVER_FILES", icdPath.c_str(), 0);
       }
     }
   }


### PR DESCRIPTION
executablePath() and executableDir() are now declared in locate.h and
implemented once in locate.cc. Drops the three copies: the Unix
executableDir() in rendererloader.cc, its inline GetModuleFileNameA
block in the Windows llvmpipe fallback, and the _NSGetExecutablePath
block in vkrender.cc.

Windows callers gain the shared implementation's wide, canonicalizing
lookup: the llvmpipe fallback no longer truncates at MAX_PATH (silently
writing lvp_icd.json to the current directory) or ignores symlinks and
junctions.